### PR TITLE
[0.x] Fixes `route:cache` command

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -105,8 +105,8 @@ class PulseServiceProvider extends ServiceProvider
      */
     protected function registerRoutes()
     {
-        Route::get(config('pulse.path'), function () {
-            $this->app->make(Pulse::class)->doNotReportUsage = true;
+        Route::get(config('pulse.path'), function (Pulse $pulse) {
+            $pulse->doNotReportUsage = true;
 
             return view('pulse::dashboard');
         })->middleware(config('pulse.middleware'));


### PR DESCRIPTION
This pull request fixes the `route:cache` command, as previously the `$this` variable was trying to be serialized by the serializable closure package.