### PR TITLE
Rename generic event

### DIFF
--- a/resources/views/livewire/servers.blade.php
+++ b/resources/views/livewire/servers.blade.php
@@ -120,7 +120,7 @@ $rows = ! empty($rows) ? $rows : 1;
                                     }
                                 )
 
-                                Livewire.on('chart-update', ({ servers }) => {
+                                Livewire.on('servers-chart-update', ({ servers }) => {
                                     // TODO: Figure out how to destroy the Alpine instance and remove this listener.
 
                                     if (chart === undefined) {
@@ -220,7 +220,7 @@ $rows = ! empty($rows) ? $rows : 1;
                                     }
                                 )
 
-                                Livewire.on('chart-update', ({ servers }) => {
+                                Livewire.on('servers-chart-update', ({ servers }) => {
                                     // TODO: Figure out how to destroy the Alpine instance and remove this listener.
 
                                     if (chart === undefined) {
@@ -300,7 +300,7 @@ $rows = ! empty($rows) ? $rows : 1;
                                             }
                                         )
 
-                                        Livewire.on('chart-update', ({ servers }) => {
+                                        Livewire.on('servers-chart-update', ({ servers }) => {
                                             // TODO: Figure out how to destroy the Alpine instance and remove this listener.
 
                                             const storage = servers['{{ $server->slug }}']?.storage?.find(storage => storage.directory === '{{ $storage->directory }}')

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -21,7 +21,7 @@ class Servers extends Card
         $servers = $query($this->periodAsInterval());
 
         if (request()->hasHeader('X-Livewire')) {
-            $this->dispatch('chart-update', servers: $servers);
+            $this->dispatch('servers-chart-update', servers: $servers);
         }
 
         return View::make('pulse::livewire.servers', [


### PR DESCRIPTION
This PR renames a generic event because we'll have additional charts for the updated queues card.