### PR TITLE
Cache servers data and show stats

### DIFF
--- a/resources/views/livewire/servers.blade.php
+++ b/resources/views/livewire/servers.blade.php
@@ -50,7 +50,7 @@ $rows = ! empty($rows) ? $rows : 1;
                 </div>
                 <div class="flex items-center pr-8 xl:pr-12 [&:nth-child(1n+15)]:border-t {{ count($servers) > 1 ? 'py-2' : '' }} {{ ! $server->recently_reported ? 'opacity-25 animate-pulse' : '' }}" :class="loadingNewDataset ? 'opacity-25 animate-pulse' : ''">
                     <x-pulse::icons.server class="w-6 h-6 mr-2 stroke-gray-500 dark:stroke-gray-400" />
-                    <span class="text-base font-bold text-gray-600 dark:text-gray-300">{{ $server->name }}</span>
+                    <span class="text-base font-bold text-gray-600 dark:text-gray-300" title="Time: {{ $time }}; Run at: {{ $runAt }};">{{ $server->name }}</span>
                 </div>
                 <div class="flex items-center [&:nth-child(1n+15)]:border-t {{ count($servers) > 1 ? 'py-2' : '' }} {{ ! $server->recently_reported ? 'opacity-25 animate-pulse' : '' }}" :class="loadingNewDataset ? 'opacity-25 animate-pulse' : ''">
                     <div class="text-xl font-bold text-gray-700 dark:text-gray-200 w-14 whitespace-nowrap tabular-nums">

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -5,20 +5,21 @@ namespace Laravel\Pulse\Livewire;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
+use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
 class Servers extends Card
 {
-    use HasPeriod, ShouldNotReportUsage;
+    use HasPeriod, RemembersQueries, ShouldNotReportUsage;
 
     /**
      * Render the component.
      */
     public function render(callable $query): Renderable
     {
-        $servers = $query($this->periodAsInterval());
+        [$servers, $time, $runAt] = $this->remember($query);
 
         if (request()->hasHeader('X-Livewire')) {
             $this->dispatch('chart-update', servers: $servers);
@@ -26,6 +27,8 @@ class Servers extends Card
 
         return View::make('pulse::livewire.servers', [
             'servers' => $servers,
+            'time' => $time,
+            'runAt' => $runAt,
         ]);
     }
 


### PR DESCRIPTION
This PR adds caching to the servers card and shows the query stats when hovering a server name so we can see how long these queries are taking.