### PR TITLE
Inject queries directly

### DIFF
--- a/src/Livewire/Cache.php
+++ b/src/Livewire/Cache.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\CacheInteractions;
+use Laravel\Pulse\Queries\MonitoredCacheInteractions;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
@@ -18,7 +20,7 @@ class Cache extends Card
     /**
      * Render the component.
      */
-    public function render(callable $cacheInteractionsQuery, callable $monitoredCacheInteractionsQuery): Renderable
+    public function render(CacheInteractions $cacheInteractionsQuery, MonitoredCacheInteractions $monitoredCacheInteractionsQuery): Renderable
     {
         $monitoring = collect(Config::get('pulse.cache_keys'))
             ->mapWithKeys(fn (string $value, int|string $key) => is_string($key)

--- a/src/Livewire/Exceptions.php
+++ b/src/Livewire/Exceptions.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\Exceptions as ExceptionsQuery;
 use Livewire\Attributes\Lazy;
 use Livewire\Attributes\Url;
 
@@ -26,7 +27,7 @@ class Exceptions extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(ExceptionsQuery $query): Renderable
     {
         $orderBy = match ($this->orderBy) {
             'last_occurrence' => 'last_occurrence',

--- a/src/Livewire/Queues.php
+++ b/src/Livewire/Queues.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\Queues as QueuesQuery;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
@@ -16,7 +17,7 @@ class Queues extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(QueuesQuery $query): Renderable
     {
         return View::make('pulse::livewire.queues', [
             'queues' => $queues = Cache::remember('laravel:pulse:queues:live', 5, fn () => $query()),

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\Servers as ServersQuery;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
@@ -16,7 +17,7 @@ class Servers extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(ServersQuery $query): Renderable
     {
         $servers = $query($this->periodAsInterval());
 

--- a/src/Livewire/SlowJobs.php
+++ b/src/Livewire/SlowJobs.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\SlowJobs as SlowJobsQuery;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
@@ -17,7 +18,7 @@ class SlowJobs extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(SlowJobsQuery $query): Renderable
     {
         [$slowJobs, $time, $runAt] = $this->remember($query);
 

--- a/src/Livewire/SlowOutgoingRequests.php
+++ b/src/Livewire/SlowOutgoingRequests.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\SlowOutgoingRequests as SlowOutgoingRequestsQuery;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
@@ -18,7 +19,7 @@ class SlowOutgoingRequests extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(SlowOutgoingRequestsQuery $query): Renderable
     {
         [$slowOutgoingRequests, $time, $runAt] = $this->remember($query);
 

--- a/src/Livewire/SlowQueries.php
+++ b/src/Livewire/SlowQueries.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\SlowQueries as SlowQueriesQuery;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
@@ -17,7 +18,7 @@ class SlowQueries extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(SlowQueriesQuery $query): Renderable
     {
         [$slowQueries, $time, $runAt] = $this->remember($query);
 

--- a/src/Livewire/SlowRoutes.php
+++ b/src/Livewire/SlowRoutes.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\SlowRoutes as SlowRoutesQuery;
 use Livewire\Attributes\Lazy;
 
 #[Lazy]
@@ -17,7 +18,7 @@ class SlowRoutes extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(SlowRoutesQuery $query): Renderable
     {
         [$slowRoutes, $time, $runAt] = $this->remember($query);
 

--- a/src/Livewire/Usage.php
+++ b/src/Livewire/Usage.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\View;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 use Laravel\Pulse\Livewire\Concerns\ShouldNotReportUsage;
+use Laravel\Pulse\Queries\Usage as UsageQuery;
 use Livewire\Attributes\Lazy;
 use Livewire\Attributes\Url;
 
@@ -33,7 +34,7 @@ class Usage extends Card
     /**
      * Render the component.
      */
-    public function render(callable $query): Renderable
+    public function render(UsageQuery $query): Renderable
     {
         $type = $this->type ?? $this->usage;
 

--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -54,7 +54,6 @@ class PulseServiceProvider extends ServiceProvider
         $this->app->bind(Storage::class, DatabaseStorage::class);
 
         $this->registerIngest();
-        $this->registerComponentMethodBindings();
     }
 
     /**
@@ -67,30 +66,6 @@ class PulseServiceProvider extends ServiceProvider
             'redis' => $app[RedisIngest::class],
             default => throw new RuntimeException("Unknown ingest driver [{$app['config']->get('pulse.ingest.driver')}]."),
         });
-    }
-
-    /**
-     * Register the Livewire component method bindings.
-     */
-    protected function registerComponentMethodBindings(): void
-    {
-        foreach ([
-            Livewire\Usage::class => [Queries\Usage::class],
-            Livewire\Queues::class => [Queries\Queues::class],
-            Livewire\Servers::class => [Queries\Servers::class],
-            Livewire\SlowJobs::class => [Queries\SlowJobs::class],
-            Livewire\Exceptions::class => [Queries\Exceptions::class],
-            Livewire\SlowRoutes::class => [Queries\SlowRoutes::class],
-            Livewire\SlowQueries::class => [Queries\SlowQueries::class],
-            Livewire\SlowOutgoingRequests::class => [Queries\SlowOutgoingRequests::class],
-            Livewire\Cache::class => [Queries\CacheInteractions::class, Queries\MonitoredCacheInteractions::class],
-        ] as $card => $queries) {
-            $this->app->bindMethod(
-                [$card, 'render'],
-                fn (Component $instance, Application $app) =>
-                    $instance->render(...array_map($app->make(...), $queries))
-            );
-        }
     }
 
     /**


### PR DESCRIPTION
This PR updates the query injection to inject the classes directly. This was originally intended to make it easier to swap out the query, but in practice, it makes the code a bit harder to understand and work with, and we don't even know whether the original intention is needed.