### PR TITLE
Add recording control middleware

### DIFF
--- a/src/Http/Middleware/PulseRecording.php
+++ b/src/Http/Middleware/PulseRecording.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Pulse\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Laravel\Pulse\Pulse;
+
+class PulseRecording
+{
+    /**
+     * Create a new middleware instance.
+     */
+    public function __construct(protected Pulse $pulse)
+    {
+        //
+    }
+
+    /**
+     * Start recording.
+     */
+    public static function start(): string
+    {
+        return static::class.':start,'.Str::random();
+    }
+
+    /**
+     * Stop recording.
+     */
+    public static function stop(): string
+    {
+        return static::class.':stop,'.Str::random();
+    }
+
+    /**
+     * Handle the incoming request.
+     */
+    public function handle(Request $request, Closure $next, string $action): mixed
+    {
+        match ($action) {
+            'start' => $this->pulse->startRecording(),
+            'stop' => $this->pulse->stopRecording(),
+        };
+
+        return $next($request);
+    }
+}

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -234,12 +234,6 @@ class Pulse
      */
     public function store(Ingest $ingest): self
     {
-        if (! $this->shouldRecord) {
-            $this->rememberedUserId = null;
-
-            return $this->flushEntries();
-        }
-
         $this->rescue(fn () => $ingest->ingest(
             $this->entries->map->resolve()->filter($this->shouldRecord(...)),
         ));

--- a/tests/Feature/RecordingControlMiddlewareTest.php
+++ b/tests/Feature/RecordingControlMiddlewareTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Laravel\Pulse\Http\Middleware\PulseRecording;
+
+use function Pest\Laravel\get;
+
+it('can stop control recording via middleware', function () {
+    Route::get('test-route', fn () => 'ok')->middleware([
+        MyMiddleware::class.':first',
+        PulseRecording::stop(),
+        MyMiddleware::class.':second',
+        PulseRecording::start(),
+        MyMiddleware::class.':third',
+        PulseRecording::stop(),
+        MyMiddleware::class.':fourth',
+        PulseRecording::start(),
+        MyMiddleware::class.':fifth',
+        PulseRecording::stop(),
+        MyMiddleware::class.':sixth',
+    ]);
+
+    $response = get('test-route');
+
+    $response->assertOk();
+    $interactions = Pulse::ignore(fn () => DB::table('pulse_cache_interactions')->get());
+    expect($interactions->pluck('key')->all())->toBe([
+        'first',
+        'third',
+        'fifth',
+    ]);
+});
+
+class MyMiddleware
+{
+    public function handle($request, $next, $key)
+    {
+        Cache::get($key);
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
this won’t work. Gonna need a middleware decorator.

`PulseRecording::ignore([...])`?