### PR TITLE
Throw named exception for unsupported commands

### DIFF
--- a/src/Exceptions/RedisVersionException.php
+++ b/src/Exceptions/RedisVersionException.php
@@ -6,8 +6,18 @@ use RuntimeException;
 
 class RedisVersionException extends RuntimeException
 {
-    public function __construct(public string $command, public string $minimum, public string $actual)
+    /**
+     * @var list<string>
+     */
+    public array $commands;
+
+    /**
+     * @param  string|list<string>  $commands
+     */
+    public function __construct(string|array $commands, public string $minimum, public string $actual)
     {
-        parent::__construct("Pulse requires Redis [{$minimum}] or higher. Found [{$actual}].");
+        $this->commands = (array) $commands;
+
+        parent::__construct("Pulse requires Redis [{$minimum}] or higher. Found [{$actual}] while running ".collect($this->commands)->map(fn ($command) => "[$command]")->implode(',').'.');
     }
 }

--- a/src/Ingests/Redis.php
+++ b/src/Ingests/Redis.php
@@ -46,7 +46,7 @@ class Redis implements Ingest
             $items->each(fn (Entry|Update $entry) => $pipeline->xadd($this->stream, [
                 'data' => serialize($entry),
             ]));
-        });
+        }, 'XADD');
     }
 
     /**


### PR DESCRIPTION
PHPRedis returns `false` on error. It does not throw. Need to get that covered as well.