### PR TITLE
Distinguish Livewire requests

### DIFF
--- a/src/Queries/SlowRoutes.php
+++ b/src/Queries/SlowRoutes.php
@@ -66,18 +66,27 @@ class SlowRoutes
             ->map(function (stdClass $row) use ($routes) {
                 [$method, $uri] = explode(' ', $row->route, 2);
 
+                preg_match('/(.*?)(?:\s\((.*)\))?$/', $uri, $matches);
+
+                [$uri, $via] = [$matches[1], $matches[2] ?? null];
+
                 $domain = Str::before($uri, '/');
 
                 if ($domain) {
                     $uri = '/'.Str::after($uri, '/');
                 }
 
-                $path = $uri === '/' ? $uri : ltrim($uri, '/');
+                if ($via) {
+                    $action = 'via '.$via;
+                } else {
+                    $path = $uri === '/' ? $uri : ltrim($uri, '/');
+                    $action = ($route = $routes[$method][$domain.$path] ?? null) ? (string) $route->getActionName() : null;
+                }
 
                 return (object) [
                     'uri' => $domain.$uri,
                     'method' => $method,
-                    'action' => ($route = $routes[$method][$domain.$path] ?? null) ? (string) $route->getActionName() : null,
+                    'action' => $action,
                     'count' => (int) $row->count,
                     'slowest' => (int) $row->slowest,
                 ];

--- a/src/Recorders/Requests.php
+++ b/src/Recorders/Requests.php
@@ -56,31 +56,27 @@ class Requests
         }
 
         $path = $route->getDomain().Str::start($route->uri(), '/');
+        $via = null;
 
-        if (! $this->shouldSample() || $this->shouldIgnore($path) || $this->shouldIgnoreLivewireRequest($request)) {
+        if ($route->named('*livewire.update')) {
+            $snapshot = json_decode($request->input('components.0.snapshot'));
+
+            if (isset($snapshot->memo->path)) {
+                $via = $path;
+                $path = Str::start($snapshot->memo->path, '/');
+            }
+        }
+
+        if (! $this->shouldSample() || $this->shouldIgnore($path)) {
             return null;
         }
 
         return new Entry($this->table, [
             'date' => $startedAt->toDateTimeString(),
-            'route' => $request->method().' '.$path,
+            'route' => $request->method().' '.$path.($via ? " ($via)" : ''),
             'duration' => $duration = $startedAt->diffInMilliseconds(),
             'user_id' => $this->pulse->authenticatedUserIdResolver(),
             'slow' => $duration >= $this->config->get('pulse.recorders.'.static::class.'.threshold'),
         ]);
-    }
-
-    /**
-     * Determine whether any Livewire component updates should be ignored.
-     */
-    protected function shouldIgnoreLivewireRequest(Request $request): bool
-    {
-        if (! ($route = $request->route()) instanceof Route || ! $route->named('*livewire.update')) {
-            return false;
-        }
-
-        return $request
-            ->collect('components.*.snapshot')
-            ->contains(fn ($snapshot) => $this->shouldIgnore(Str::start(json_decode($snapshot)->memo->path, '/')));
     }
 }


### PR DESCRIPTION
All Livewire update requests are currently grouped under a single path (`/livewire/update`).

This PR updates the request recorder to capture the original path that triggered the Livewire request while maintaining the fact that it was a Livewire request.