### PR TITLE
Add ability to disable location capture and grouping

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -143,6 +143,7 @@ return [
         Recorders\Exceptions::class => [
             'enabled' => env('PULSE_EXCEPTIONS_ENABLED', true),
             'sample_rate' => env('PULSE_EXCEPTIONS_SAMPLE_RATE', 1),
+            'location' => env('PULSE_EXCEPTIONS_LOCATION', true),
             'ignore' => [
                 // '/^Package\\\\Exceptions\\\\/',
             ],
@@ -184,6 +185,7 @@ return [
             'enabled' => env('PULSE_SLOW_QUERIES_ENABLED', true),
             'sample_rate' => env('PULSE_SLOW_QUERIES_SAMPLE_RATE', 1),
             'threshold' => env('PULSE_SLOW_QUERY_THRESHOLD', 1000),
+            'location' => env('PULSE_SLOW_QUERY_LOCATION', true),
             'ignore' => [
                 '/(["`])pulse_[\w]+?\1/', // Pulse tables
             ],

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -57,7 +57,7 @@ class SlowQueries
         return new Entry($this->table, [
             'date' => $now->subMilliseconds((int) $event->time)->toDateTimeString(),
             'sql' => $event->sql,
-            'location' => $this->getLocation(),
+            'location' => $this->config->get('pulse.recorders.'.self::class.'.location') ? $this->getLocation() : '',
             'duration' => (int) $event->time,
             'user_id' => $this->pulse->authenticatedUserIdResolver(),
         ]);

--- a/tests/Feature/Recorders/ExceptionsTest.php
+++ b/tests/Feature/Recorders/ExceptionsTest.php
@@ -37,6 +37,23 @@ it('ingests exceptions', function () {
     ]);
 });
 
+it('can disable capturing the location', function () {
+    Config::set('pulse.recorders.'.Exceptions::class.'.location', false);
+    Carbon::setTestNow('2000-01-02 03:04:05');
+
+    report(new RuntimeException('Expected exception.'));
+    Pulse::store(app(Ingest::class));
+
+    $exceptions = Pulse::ignore(fn () => DB::table('pulse_exceptions')->get());
+    expect($exceptions)->toHaveCount(1);
+    expect($exceptions[0])->toHaveProperties([
+        'date' => '2000-01-02 03:04:05',
+        'user_id' => null,
+        'class' => 'RuntimeException',
+        'location' => '',
+    ]);
+});
+
 it('captures the authenticated user', function () {
     Auth::login(User::make(['id' => '567']));
 


### PR DESCRIPTION
Adds the ability to disable the capture of exception and slow query locations, which will prevent duplicate exceptions/queries appearing but lose the ability to see where they originated.