### PR TITLE
[1.x] Postgres support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  tests:
+  mysql:
     runs-on: ubuntu-22.04
 
     services:
@@ -18,7 +18,7 @@ jobs:
         image: mysql:5.7
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: testing
+          MYSQL_DATABASE: forge
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -35,7 +35,7 @@ jobs:
         laravel: [10]
         stability: [prefer-lowest, prefer-stable]
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - MySQL 5.7
 
     steps:
       - name: Checkout code
@@ -62,3 +62,57 @@ jobs:
         env:
           DB_CONNECTION: mysql
           DB_USERNAME: root
+
+  pgsql:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgresql:
+        image: postgres:14
+        env:
+          POSTGRES_DB: forge
+          POSTGRES_USER: forge
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.3]
+        laravel: [10]
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - PostgreSQL 14
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install redis-cli
+        run: sudo apt-get install -qq redis-tools
+
+      - name: Install dependencies
+        run: |
+           composer require "illuminate/contracts=^${{ matrix.laravel }}" --dev --no-update
+           composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/pest
+        env:
+          DB_CONNECTION: pgsql
+          DB_PASSWORD: password

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -45,7 +45,6 @@ return new class extends Migration
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->text('key');
-            $table->bigInteger('value')->nullable();
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->char('key_hash', 32)->storedAs('md5("key")'),

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -30,7 +30,7 @@ return new class extends Migration
             $table->text('key');
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
-                'pgsql' => $table->char('key_hash', 32)->storedAs('md5("key")'),
+                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->text('value');
@@ -47,7 +47,7 @@ return new class extends Migration
             $table->text('key');
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
-                'pgsql' => $table->char('key_hash', 32)->storedAs('md5("key")'),
+                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->bigInteger('value')->nullable();
@@ -66,7 +66,7 @@ return new class extends Migration
             $table->text('key');
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
-                'pgsql' => $table->char('key_hash', 32)->storedAs('md5("key")'),
+                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->string('aggregate');

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -20,25 +21,36 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('pulse_values', function (Blueprint $table) {
+        $connection = $this->getConnection() ?? DB::connection();
+
+        Schema::create('pulse_values', function (Blueprint $table) use ($connection) {
             $table->engine = 'InnoDB';
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->text('key');
-            $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))');
+            match ($driver = $connection->getDriverName()) {
+                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'pgsql' => $table->char('key_hash', 32)->storedAs('md5("key")'),
+                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
+            };
             $table->text('value');
 
             $table->index('timestamp'); // For trimming...
             $table->index('type'); // For fast lookups and purging...
-            $table->unique(['type', 'key_hash']); // For data integrity...
+            $table->unique(['type', 'key_hash']); // For data integrity and upserts...
         });
 
-        Schema::create('pulse_entries', function (Blueprint $table) {
+        Schema::create('pulse_entries', function (Blueprint $table) use ($connection) {
             $table->engine = 'InnoDB';
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->text('key');
-            $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))');
+            $table->bigInteger('value')->nullable();
+            match ($driver = $connection->getDriverName()) {
+                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'pgsql' => $table->char('key_hash', 32)->storedAs('md5("key")'),
+                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
+            };
             $table->bigInteger('value')->nullable();
 
             $table->index('timestamp'); // For trimming...
@@ -47,13 +59,17 @@ return new class extends Migration
             $table->index(['timestamp', 'type', 'key_hash', 'value']); // For aggregate queries...
         });
 
-        Schema::create('pulse_aggregates', function (Blueprint $table) {
+        Schema::create('pulse_aggregates', function (Blueprint $table) use ($connection) {
             $table->engine = 'InnoDB';
             $table->unsignedInteger('bucket');
             $table->unsignedMediumInteger('period');
             $table->string('type');
             $table->text('key');
-            $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))');
+            match ($driver = $connection->getDriverName()) {
+                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'pgsql' => $table->char('key_hash', 32)->storedAs('md5("key")'),
+                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
+            };
             $table->string('aggregate');
             $table->decimal('value', 20, 2);
             $table->unsignedInteger('count')->nullable();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,5 @@
     </testsuites>
     <php>
         <env name="APP_KEY" value="base64:uz4B1RtFO57QGzbZX1kRYX9hIRB50+QzqFeg9zbFJlY="/>
-        <env name="DB_CONNECTION" value="mysql"/>
-        <env name="DB_DATABASE" value="testing"/>
-        <env name="DB_USERNAME" value="root"/>
     </php>
 </phpunit>

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -55,13 +55,6 @@ class DatabaseStorage implements Storage
                     ->insert($chunk->map->attributes()->all())
                 );
 
-            $periods = [
-                (int) (CarbonInterval::hour()->totalSeconds / 60),
-                (int) (CarbonInterval::hours(6)->totalSeconds / 60),
-                (int) (CarbonInterval::hours(24)->totalSeconds / 60),
-                (int) (CarbonInterval::days(7)->totalSeconds / 60),
-            ];
-
             $this
                 ->aggregateCounts($entries->filter->isCount())
                 ->chunk($this->config->get('pulse.storage.database.chunk'))
@@ -690,7 +683,7 @@ class DatabaseStorage implements Storage
     }
 
     /**
-     * Wrap a value in keyword identifiers
+     * Wrap a value in keyword identifiers.
      */
     protected function wrap(string $value): string
     {

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -211,7 +211,7 @@ class DatabaseStorage implements Storage
 
         foreach ($entries as $entry) {
             foreach ($this->periods() as $period) {
-                // TODO: add back the comment
+                // Exclude entries that would be trimmed.
                 if ($entry->timestamp < CarbonImmutable::now()->subMinutes($period)->getTimestamp()) {
                     continue;
                 }
@@ -250,6 +250,7 @@ class DatabaseStorage implements Storage
 
         foreach ($entries as $entry) {
             foreach ($this->periods() as $period) {
+                // Exclude entries that would be trimmed.
                 if ($entry->timestamp < CarbonImmutable::now()->subMinutes($period)->getTimestamp()) {
                     continue;
                 }
@@ -288,6 +289,7 @@ class DatabaseStorage implements Storage
 
         foreach ($entries as $entry) {
             foreach ($this->periods() as $period) {
+                // Exclude entries that would be trimmed.
                 if ($entry->timestamp < CarbonImmutable::now()->subMinutes($period)->getTimestamp()) {
                     continue;
                 }

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -154,8 +154,8 @@ class DatabaseStorage implements Storage
         return $this->upsert(
             $values,
             match ($driver = $this->connection()->getDriverName()) {
-                'mysql' => 'on duplicate key update `value` = `value` + 1',
-                'pgsql' => 'on conflict ("bucket", "period", "type", "aggregate", "key_hash") do update set "value" = "pulse_aggregates"."value" + 1',
+                'mysql' => 'on duplicate key update `value` = `value` + values(`value`)',
+                'pgsql' => 'on conflict ("bucket", "period", "type", "aggregate", "key_hash") do update set "value" = "pulse_aggregates"."value" + "excluded"."value"',
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
             }
         );
@@ -188,8 +188,8 @@ class DatabaseStorage implements Storage
         return $this->upsert(
             $values,
             match ($driver = $this->connection()->getDriverName()) {
-                'mysql' => 'on duplicate key update `value` = (`value` * `count` + values(`value`)) / (`count` + 1), `count` = `count` + values(`count`)',
-                'pgsql' => 'on conflict ("bucket", "period", "type", "aggregate", "key_hash") do update set "value" = ("pulse_aggregates"."value" * "pulse_aggregates"."count" + "excluded"."value") / ("pulse_aggregates"."count" + 1), "count" = "pulse_aggregates"."count" + "excluded"."count"',
+                'mysql' => 'on duplicate key update `value` = (`value` * `count` + (values(`value`) * values(`count`))) / (`count` + values(`count`)), `count` = `count` + values(`count`)',
+                'pgsql' => 'on conflict ("bucket", "period", "type", "aggregate", "key_hash") do update set "value" = ("pulse_aggregates"."value" * "pulse_aggregates"."count" + ("excluded"."value" * "excluded"."count")) / ("pulse_aggregates"."count" + "excluded"."count"), "count" = "pulse_aggregates"."count" + "excluded"."count"',
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
             }
         );

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -188,8 +188,8 @@ class DatabaseStorage implements Storage
         return $this->upsert(
             $values,
             match ($driver = $this->connection()->getDriverName()) {
-                'mysql' => 'on duplicate key update `value` = (`value` * `count` + values(`value`)) / (`count` + 1), `count` = `count` + 1',
-                'pgsql' => 'on conflict ("bucket", "period", "type", "aggregate", "key_hash") do update set "value" = ("pulse_aggregates"."value" * "pulse_aggregates"."count" + "excluded"."value") / ("pulse_aggregates"."count" + 1), "count" = "pulse_aggregates"."count" + 1',
+                'mysql' => 'on duplicate key update `value` = (`value` * `count` + values(`value`)) / (`count` + 1), `count` = `count` + values(`count`)',
+                'pgsql' => 'on conflict ("bucket", "period", "type", "aggregate", "key_hash") do update set "value" = ("pulse_aggregates"."value" * "pulse_aggregates"."count" + "excluded"."value") / ("pulse_aggregates"."count" + 1), "count" = "pulse_aggregates"."count" + "excluded"."count"',
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
             }
         );

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -443,10 +443,10 @@ class DatabaseStorage implements Storage
 
                 foreach ($aggregates as $aggregate) {
                     $query->selectRaw(match ($aggregate) {
-                        'count' => 'sum('.$this->wrap('count').')',
-                        'max' => 'max('.$this->wrap('max').')',
-                        'avg' => 'avg('.$this->wrap('avg').')',
-                    }.' as '.$this->wrap($aggregate));
+                        'count' => "sum({$this->wrap('count')})",
+                        'max' => "max({$this->wrap('max')})",
+                        'avg' => "avg({$this->wrap('avg')})",
+                    }." as {$this->wrap($aggregate)}");
                 }
 
                 $query->fromSub(function (Builder $query) use ($type, $aggregates, $interval) {
@@ -462,9 +462,9 @@ class DatabaseStorage implements Storage
                     foreach ($aggregates as $aggregate) {
                         $query->selectRaw(match ($aggregate) {
                             'count' => 'count(*)',
-                            'max' => 'max('.$this->wrap('value').')',
-                            'avg' => 'avg('.$this->wrap('value').')',
-                        }.' as '.$this->wrap($aggregate));
+                            'max' => "max({$this->wrap('value')})",
+                            'avg' => "avg({$this->wrap('value')})",
+                        }." as {$this->wrap($aggregate)}");
                     }
 
                     $query
@@ -482,12 +482,12 @@ class DatabaseStorage implements Storage
                             foreach ($aggregates as $aggregate) {
                                 if ($aggregate === $currentAggregate) {
                                     $query->selectRaw(match ($aggregate) {
-                                        'count' => 'sum('.$this->wrap('value').')',
-                                        'max' => 'max('.$this->wrap('value').')',
-                                        'avg' => 'avg('.$this->wrap('value').')',
-                                    }.' as '.$this->wrap($aggregate));
+                                        'count' => "sum({$this->wrap('value')})",
+                                        'max' => "max({$this->wrap('value')})",
+                                        'avg' => "avg({$this->wrap('value')})",
+                                    }." as {$this->wrap($aggregate)}");
                                 } else {
-                                    $query->selectRaw('null as '.$this->wrap($aggregate));
+                                    $query->selectRaw("null as {$this->wrap($aggregate)}");
                                 }
                             }
 
@@ -545,10 +545,10 @@ class DatabaseStorage implements Storage
 
                 foreach ($types as $type) {
                     $query->selectRaw(match ($aggregate) {
-                        'count' => 'sum('.$this->wrap($type).')',
-                        'max' => 'max('.$this->wrap($type).')',
-                        'avg' => 'avg('.$this->wrap($type).')',
-                    }.' as '.$this->wrap($type));
+                        'count' => "sum({$this->wrap($type)})",
+                        'max' => "max({$this->wrap($type)})",
+                        'avg' => "avg({$this->wrap($type)})",
+                    }." as {$this->wrap($type)}");
                 }
 
                 $query->fromSub(function (Builder $query) use ($types, $aggregate, $interval) {
@@ -563,10 +563,10 @@ class DatabaseStorage implements Storage
 
                     foreach ($types as $type) {
                         $query->selectRaw(match ($aggregate) {
-                            'count' => 'count(case when ('.$this->wrap('type').' = ?) then true else null end)',
-                            'max' => 'max(case when ('.$this->wrap('type').' = ?) then '.$this->wrap('value').' else null end)',
-                            'avg' => 'avg(case when ('.$this->wrap('type').' = ?) then '.$this->wrap('value').' else null end)',
-                        }.' as '.$this->wrap($type), [$type]);
+                            'count' => "count(case when ({$this->wrap('type')} = ?) then true else null end)",
+                            'max' => "max(case when ({$this->wrap('type')} = ?) then {$this->wrap('value')} else null end)",
+                            'avg' => "avg(case when ({$this->wrap('type')} = ?) then {$this->wrap('value')} else null end)",
+                        }." as {$this->wrap($type)}", [$type]);
                     }
 
                     $query
@@ -582,10 +582,10 @@ class DatabaseStorage implements Storage
 
                         foreach ($types as $type) {
                             $query->selectRaw(match ($aggregate) {
-                                'count' => 'sum(case when ('.$this->wrap('type').' = ?) then '.$this->wrap('value').' else null end)',
-                                'max' => 'max(case when ('.$this->wrap('type').' = ?) then '.$this->wrap('value').' else null end)',
-                                'avg' => 'avg(case when ('.$this->wrap('type').' = ?) then '.$this->wrap('value').' else null end)',
-                            }.' as '.$this->wrap($type), [$type]);
+                                'count' => "sum(case when ({$this->wrap('type')} = ?) then {$this->wrap('value')} else null end)",
+                                'max' => "max(case when ({$this->wrap('type')} = ?) then {$this->wrap('value')} else null end)",
+                                'avg' => "avg(case when ({$this->wrap('type')} = ?) then {$this->wrap('value')} else null end)",
+                            }." as {$this->wrap($type)}", [$type]);
                         }
 
                         $query
@@ -633,18 +633,18 @@ class DatabaseStorage implements Storage
         return $this->connection()->query()
             ->addSelect('type')
             ->selectRaw(match ($aggregate) {
-                'count' => 'sum('.$this->wrap('count').')',
-                'max' => 'max('.$this->wrap('max').')',
-                'avg' => 'avg('.$this->wrap('avg').')',
-            }.' as '.$this->wrap($aggregate))
+                'count' => "sum({$this->wrap('count')})",
+                'max' => "max({$this->wrap('max')})",
+                'avg' => "avg({$this->wrap('avg')})",
+            }." as {$this->wrap($aggregate)}")
             ->fromSub(fn (Builder $query) => $query
                 // Tail
                 ->addSelect('type')
                 ->selectRaw(match ($aggregate) {
                     'count' => 'count(*)',
-                    'max' => 'max('.$this->wrap('value').')',
-                    'avg' => 'avg('.$this->wrap('value').')',
-                }.' as '.$this->wrap($aggregate))
+                    'max' => "max({$this->wrap('value')})",
+                    'avg' => "avg({$this->wrap('value')})",
+                }." as {$this->wrap($aggregate)}")
                 ->from('pulse_entries')
                 ->whereIn('type', $types)
                 ->where('timestamp', '>=', $tailStart)
@@ -654,10 +654,10 @@ class DatabaseStorage implements Storage
                 ->unionAll(fn (Builder $query) => $query
                     ->select('type')
                     ->selectRaw(match ($aggregate) {
-                        'count' => 'sum('.$this->wrap('value').')',
-                        'max' => 'max('.$this->wrap('value').')',
-                        'avg' => 'avg('.$this->wrap('value').')',
-                    }.' as '.$this->wrap($aggregate))
+                        'count' => "sum({$this->wrap('value')})",
+                        'max' => "max({$this->wrap('value')})",
+                        'avg' => "avg({$this->wrap('value')})",
+                    }." as {$this->wrap($aggregate)}")
                     ->from('pulse_aggregates')
                     ->where('period', $period)
                     ->whereIn('type', $types)

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -140,7 +140,7 @@ class DatabaseStorage implements Storage
      *
      * @param  list<AggregateRow>  $values
      */
-    protected function upsertCount(array $values): bool
+    protected function upsertCount(array $values): int
     {
         return $this->connection()->table('pulse_aggregates')->upsert(
             $values,
@@ -160,7 +160,7 @@ class DatabaseStorage implements Storage
      *
      * @param  list<AggregateRow>  $values
      */
-    protected function upsertMax(array $values): bool
+    protected function upsertMax(array $values): int
     {
         return $this->connection()->table('pulse_aggregates')->upsert(
             $values,
@@ -180,7 +180,7 @@ class DatabaseStorage implements Storage
      *
      * @param  list<AggregateRow>  $values
      */
-    protected function upsertAvg(array $values): bool
+    protected function upsertAvg(array $values): int
     {
         return $this->connection()->table('pulse_aggregates')->upsert(
             $values,

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -150,7 +150,7 @@ class DatabaseStorage implements Storage
                     'mysql' => new Expression('`value` + values(`value`)'),
                     'pgsql' => new Expression('"pulse_aggregates"."value" + "excluded"."value"'),
                     default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
-                }
+                },
             ]
         );
     }
@@ -170,7 +170,7 @@ class DatabaseStorage implements Storage
                     'mysql' => new Expression('greatest(`value`, values(`value`))'),
                     'pgsql' => new Expression('greatest("pulse_aggregates"."value", "excluded"."value")'),
                     default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
-                }
+                },
             ]
         );
     }

--- a/tests/Feature/Recorders/SlowRequestsTest.php
+++ b/tests/Feature/Recorders/SlowRequestsTest.php
@@ -28,7 +28,7 @@ it('captures requests over the threshold', function () {
     expect($entries[0]->timestamp)->toBe(946782245);
     expect($entries[0]->type)->toBe('slow_request');
     expect($entries[0]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($entries[0]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($entries[0]->value)->toBe(4000);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('type')->orderBy('period')->orderBy('aggregate')->get());
@@ -39,7 +39,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[0]->type)->toBe('slow_request');
     expect($aggregates[0]->aggregate)->toBe('count');
     expect($aggregates[0]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[0]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[0]->value)->toBe('1.00');
 
     expect($aggregates[1]->bucket)->toBe(946782240);
@@ -47,7 +47,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[1]->type)->toBe('slow_request');
     expect($aggregates[1]->aggregate)->toBe('max');
     expect($aggregates[1]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[1]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[1]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[1]->value)->toBe('4000.00');
 
     expect($aggregates[2]->bucket)->toBe(946782000);
@@ -55,7 +55,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[2]->type)->toBe('slow_request');
     expect($aggregates[2]->aggregate)->toBe('count');
     expect($aggregates[2]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[2]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[2]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[2]->value)->toBe('1.00');
 
     expect($aggregates[3]->bucket)->toBe(946782000);
@@ -63,7 +63,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[3]->type)->toBe('slow_request');
     expect($aggregates[3]->aggregate)->toBe('max');
     expect($aggregates[3]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[3]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[3]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[3]->value)->toBe('4000.00');
 
     expect($aggregates[4]->bucket)->toBe(946781280);
@@ -71,7 +71,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[4]->type)->toBe('slow_request');
     expect($aggregates[4]->aggregate)->toBe('count');
     expect($aggregates[4]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[4]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[4]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[4]->value)->toBe('1.00');
 
     expect($aggregates[5]->bucket)->toBe(946781280);
@@ -79,21 +79,21 @@ it('captures requests over the threshold', function () {
     expect($aggregates[5]->type)->toBe('slow_request');
     expect($aggregates[5]->aggregate)->toBe('max');
     expect($aggregates[5]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[5]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[5]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[5]->value)->toBe('4000.00');
 
     expect($aggregates[6]->period)->toBe(10080);
     expect($aggregates[6]->type)->toBe('slow_request');
     expect($aggregates[6]->aggregate)->toBe('count');
     expect($aggregates[6]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[6]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[6]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[6]->value)->toBe('1.00');
 
     expect($aggregates[7]->period)->toBe(10080);
     expect($aggregates[7]->type)->toBe('slow_request');
     expect($aggregates[7]->aggregate)->toBe('max');
     expect($aggregates[7]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
-    expect($aggregates[7]->key_hash)->toBe(hex2bin(md5(json_encode(['GET', '/test-route', 'Closure']))));
+    expect($aggregates[7]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[7]->value)->toBe('4000.00');
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
@@ -114,7 +114,7 @@ it('captures slow requests per user', function () {
     expect($entries[0]->timestamp)->toBe(946782245);
     expect($entries[0]->type)->toBe('slow_user_request');
     expect($entries[0]->key)->toBe('4321');
-    expect($entries[0]->key_hash)->toBe(hex2bin(md5('4321')));
+    expect($entries[0]->key_hash)->toBe(keyHash('4321'));
     expect($entries[0]->value)->toBeNull();
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'slow_user_request')->orderBy('period')->orderBy('aggregate')->get());
@@ -125,7 +125,7 @@ it('captures slow requests per user', function () {
     expect($aggregates[0]->type)->toBe('slow_user_request');
     expect($aggregates[0]->aggregate)->toBe('count');
     expect($aggregates[0]->key)->toBe('4321');
-    expect($aggregates[0]->key_hash)->toBe(hex2bin(md5('4321')));
+    expect($aggregates[0]->key_hash)->toBe(keyHash('4321'));
     expect($aggregates[0]->value)->toBe('1.00');
 
     expect($aggregates[1]->bucket)->toBe(946782000);
@@ -133,7 +133,7 @@ it('captures slow requests per user', function () {
     expect($aggregates[1]->type)->toBe('slow_user_request');
     expect($aggregates[1]->aggregate)->toBe('count');
     expect($aggregates[1]->key)->toBe('4321');
-    expect($aggregates[1]->key_hash)->toBe(hex2bin(md5('4321')));
+    expect($aggregates[1]->key_hash)->toBe(keyHash('4321'));
     expect($aggregates[1]->value)->toBe('1.00');
 
     expect($aggregates[2]->bucket)->toBe(946781280);
@@ -141,14 +141,14 @@ it('captures slow requests per user', function () {
     expect($aggregates[2]->type)->toBe('slow_user_request');
     expect($aggregates[2]->aggregate)->toBe('count');
     expect($aggregates[2]->key)->toBe('4321');
-    expect($aggregates[2]->key_hash)->toBe(hex2bin(md5('4321')));
+    expect($aggregates[2]->key_hash)->toBe(keyHash('4321'));
     expect($aggregates[2]->value)->toBe('1.00');
 
     expect($aggregates[3]->period)->toBe(10080);
     expect($aggregates[3]->type)->toBe('slow_user_request');
     expect($aggregates[3]->aggregate)->toBe('count');
     expect($aggregates[3]->key)->toBe('4321');
-    expect($aggregates[3]->key_hash)->toBe(hex2bin(md5('4321')));
+    expect($aggregates[3]->key_hash)->toBe(keyHash('4321'));
     expect($aggregates[3]->value)->toBe('1.00');
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
@@ -268,7 +268,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($entries[0]->timestamp)->toBe(946782245);
     expect($entries[0]->type)->toBe('slow_request');
     expect($entries[0]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($entries[0]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($entries[0]->value)->toBe(4000);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('type')->orderBy('period')->orderBy('aggregate')->get());
@@ -279,7 +279,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[0]->type)->toBe('slow_request');
     expect($aggregates[0]->aggregate)->toBe('count');
     expect($aggregates[0]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[0]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[0]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[0]->value)->toBe('1.00');
 
     expect($aggregates[1]->bucket)->toBe(946782240);
@@ -287,7 +287,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[1]->type)->toBe('slow_request');
     expect($aggregates[1]->aggregate)->toBe('max');
     expect($aggregates[1]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[1]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[1]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[1]->value)->toBe('4000.00');
 
     expect($aggregates[2]->bucket)->toBe(946782000);
@@ -295,7 +295,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[2]->type)->toBe('slow_request');
     expect($aggregates[2]->aggregate)->toBe('count');
     expect($aggregates[2]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[2]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[2]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[2]->value)->toBe('1.00');
 
     expect($aggregates[3]->bucket)->toBe(946782000);
@@ -303,7 +303,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[3]->type)->toBe('slow_request');
     expect($aggregates[3]->aggregate)->toBe('max');
     expect($aggregates[3]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[3]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[3]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[3]->value)->toBe('4000.00');
 
     expect($aggregates[4]->bucket)->toBe(946781280);
@@ -311,7 +311,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[4]->type)->toBe('slow_request');
     expect($aggregates[4]->aggregate)->toBe('count');
     expect($aggregates[4]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[4]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[4]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[4]->value)->toBe('1.00');
 
     expect($aggregates[5]->bucket)->toBe(946781280);
@@ -319,7 +319,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[5]->type)->toBe('slow_request');
     expect($aggregates[5]->aggregate)->toBe('max');
     expect($aggregates[5]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[5]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[5]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[5]->value)->toBe('4000.00');
 
     expect($aggregates[6]->bucket)->toBe(946774080);
@@ -327,7 +327,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[6]->type)->toBe('slow_request');
     expect($aggregates[6]->aggregate)->toBe('count');
     expect($aggregates[6]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[6]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[6]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[6]->value)->toBe('1.00');
 
     expect($aggregates[7]->bucket)->toBe(946774080);
@@ -335,7 +335,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[7]->type)->toBe('slow_request');
     expect($aggregates[7]->aggregate)->toBe('max');
     expect($aggregates[7]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
-    expect($aggregates[7]->key_hash)->toBe(hex2bin(md5(json_encode(['POST', '/test-route', 'via /livewire/update']))));
+    expect($aggregates[7]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[7]->value)->toBe('4000.00');
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -74,8 +74,8 @@ it('combines duplicate average aggregates before upserting', function () {
     Pulse::record('type', 'key1', 400)->avg();
     Pulse::store();
     $aggregate = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->where('key', 'key1')->first());
-    expect($aggregate->value)->toEqual(250);
     expect($aggregate->count)->toEqual(6);
+    expect($aggregate->value)->toEqual(300);
 });
 
 test('one or more aggregates for a single type', function () {

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -68,6 +68,14 @@ it('combines duplicate average aggregates before upserting', function () {
     expect($aggregates['key2']->value)->toEqual(100);
     expect($aggregates['key1']->count)->toEqual(3);
     expect($aggregates['key2']->count)->toEqual(1);
+
+    Pulse::record('type', 'key1', 400)->avg();
+    Pulse::record('type', 'key1', 400)->avg();
+    Pulse::record('type', 'key1', 400)->avg();
+    Pulse::store();
+    $aggregate = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->where('key', 'key1')->first());
+    expect($aggregate->value)->toEqual(250);
+    expect($aggregate->count)->toEqual(6);
 });
 
 test('one or more aggregates for a single type', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Laravel\Pulse\Facades\Pulse;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
 
 /*
@@ -96,7 +97,7 @@ function keyHash(string $string): string
 {
     return match (DB::connection()->getDriverName()) {
         'mysql' => hex2bin(md5($string)),
-        'pgsql' => md5($string),
+        'pgsql' => Uuid::fromString(md5($string)),
     };
 }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,6 +4,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Process;
@@ -68,7 +69,7 @@ expect()->extend('toContainAggregateForAllPeriods', function (string|array $type
                 'type' => $type,
                 'aggregate' => $aggregate,
                 'key' => $key,
-                'key_hash' => hex2bin(md5($key)),
+                'key_hash' => keyHash($key),
                 'value' => $value,
                 'count' => $count,
             ];
@@ -90,6 +91,14 @@ expect()->extend('toContainAggregateForAllPeriods', function (string|array $type
 | global functions to help you to reduce the number of lines of code in your test files.
 |
 */
+
+function keyHash(string $string): string
+{
+    return match (DB::connection()->getDriverName()) {
+        'mysql' => hex2bin(md5($string)),
+        'pgsql' => md5($string),
+    };
+}
 
 function prependListener(string $event, callable $listener): void
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
@@ -21,5 +22,27 @@ abstract class TestCase extends OrchestraTestCase
     protected function defineDatabaseMigrations(): void
     {
         $this->loadMigrationsFrom(__DIR__.'/migrations');
+    }
+
+    protected function defineEnvironment($app)
+    {
+        tap($app['config'], function (Repository $config) {
+            $config->set('queue.failed.driver', 'null');
+            // TODO: Make this configurable for the environnment.
+            $config->set('database.default', 'pgsql');
+            $config->set('database.connections.pgsql', [
+                'driver' => 'pgsql',
+                'host' => env('DB_HOST', '127.0.0.1'),
+                'port' => 5432,
+                'database' => 'testing',
+                'username' => 'pulse',
+                'password' => 'secret',
+                'charset' => 'utf8',
+                'prefix' => '',
+                'prefix_indexes' => true,
+                'search_path' => 'public',
+                'sslmode' => 'prefer',
+            ]);
+        });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,25 +24,10 @@ abstract class TestCase extends OrchestraTestCase
         $this->loadMigrationsFrom(__DIR__.'/migrations');
     }
 
-    protected function defineEnvironment($app)
+    protected function defineEnvironment($app): void
     {
         tap($app['config'], function (Repository $config) {
             $config->set('queue.failed.driver', 'null');
-            // TODO: Make this configurable for the environnment.
-            $config->set('database.default', 'pgsql');
-            $config->set('database.connections.pgsql', [
-                'driver' => 'pgsql',
-                'host' => env('DB_HOST', '127.0.0.1'),
-                'port' => 5432,
-                'database' => 'testing',
-                'username' => 'pulse',
-                'password' => 'secret',
-                'charset' => 'utf8',
-                'prefix' => '',
-                'prefix_indexes' => true,
-                'search_path' => 'public',
-                'sslmode' => 'prefer',
-            ]);
         });
     }
 }


### PR DESCRIPTION
This PR introduces Postgres support for Pulse.

Note that Postgres cannot handle an upsert statement that contains multiple entries that would update the same row, so the entries have been pre-aggregated in PHP prior to the upsert. This benefits the MySQL implementation as well by reducing the number of rows being upserted, which can be especially beneficial when running the `pulse:work` command with a large backlog in the Redis stream.