### PR TITLE
Allow recording null values

### DIFF
--- a/src/Entry.php
+++ b/src/Entry.php
@@ -23,7 +23,7 @@ class Entry
         public int $timestamp,
         public string $type,
         public string $key,
-        public int $value = 1,
+        public ?int $value = null,
     ) {
         //
     }
@@ -103,7 +103,7 @@ class Entry
     /**
      * Fetch the entry attributes for persisting.
      *
-     * @return array<string, mixed>
+     * @return array{timestamp: int, type: string, key: string, value: ?int}
      */
     public function attributes(): array
     {

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -145,7 +145,7 @@ class Pulse
     public function record(
         string $type,
         string $key,
-        int $value = 1,
+        int $value = null,
         DateTimeInterface|int $timestamp = null,
     ): Entry {
         if ($timestamp === null) {

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -465,7 +465,7 @@ class DatabaseStorage implements Storage
 
                     foreach ($types as $type) {
                         $query->selectRaw(match ($aggregate) {
-                            'count' => 'count(case when (`type` = ?) then `value` else null end)',
+                            'count' => 'count(case when (`type` = ?) then true else null end)',
                             'max' => 'max(case when (`type` = ?) then `value` else null end)',
                             'avg' => 'avg(case when (`type` = ?) then `value` else null end)',
                         }." as `{$type}`", [$type]);

--- a/tests/Feature/Recorders/CacheInteractionsTest.php
+++ b/tests/Feature/Recorders/CacheInteractionsTest.php
@@ -21,13 +21,13 @@ it('ingests cache interactions', function () {
         'timestamp' => now()->timestamp,
         'type' => 'cache_hit',
         'key' => 'hit-key',
-        'value' => 1,
+        'value' => null,
     ]);
     expect($entries[1])->toHaveProperties([
         'timestamp' => now()->timestamp,
         'type' => 'cache_miss',
         'key' => 'miss-key',
-        'value' => 1,
+        'value' => null,
     ]);
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->get());
     expect($aggregates)->toHaveCount(8);
@@ -73,7 +73,7 @@ it('stores the original keys by default', function () {
         'timestamp' => now()->timestamp,
         'type' => 'cache_miss',
         'key' => 'users:1234:profile',
-        'value' => 1,
+        'value' => null,
     ]);
 });
 
@@ -92,7 +92,7 @@ it('can normalize cache keys', function () {
         'timestamp' => now()->timestamp,
         'type' => 'cache_miss',
         'key' => 'users:{user}:profile',
-        'value' => 1,
+        'value' => null,
     ]);
 });
 
@@ -111,7 +111,7 @@ it('can use back references in normalized cache keys', function () {
         'timestamp' => now()->timestamp,
         'type' => 'cache_miss',
         'key' => 'bar:foo',
-        'value' => 1,
+        'value' => null,
     ]);
 });
 
@@ -130,7 +130,7 @@ it('uses the original key if no matching pattern is found', function () {
         'timestamp' => now()->timestamp,
         'type' => 'cache_miss',
         'key' => 'actual-key',
-        'value' => 1,
+        'value' => null,
     ]);
 });
 
@@ -150,7 +150,7 @@ it('can provide regex flags in normalization key', function () {
         'timestamp' => now()->timestamp,
         'type' => 'cache_miss',
         'key' => 'lowercase-key',
-        'value' => 1,
+        'value' => null,
     ]);
 });
 

--- a/tests/Feature/Recorders/SlowRequestsTest.php
+++ b/tests/Feature/Recorders/SlowRequestsTest.php
@@ -115,7 +115,7 @@ it('captures slow requests per user', function () {
     expect($entries[0]->type)->toBe('slow_user_request');
     expect($entries[0]->key)->toBe('4321');
     expect($entries[0]->key_hash)->toBe(hex2bin(md5('4321')));
-    expect($entries[0]->value)->toBe(1);
+    expect($entries[0]->value)->toBeNull();
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'slow_user_request')->orderBy('period')->orderBy('aggregate')->get());
     expect($aggregates)->toHaveCount(4);

--- a/tests/Feature/Recorders/UserRequestsTest.php
+++ b/tests/Feature/Recorders/UserRequestsTest.php
@@ -25,7 +25,7 @@ it('captures authenticated requests', function () {
         'timestamp' => now()->timestamp,
         'type' => 'user_request',
         'key' => '567',
-        'value' => 1,
+        'value' => null,
     ]);
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->get());
     expect($aggregates)->toHaveCount(4);


### PR DESCRIPTION
The database structure already allows for a null value as it's not required for counts. This PR updates the PHP side to support that.