### PR TITLE
Fix Class "Str" not found error on fresh install

### DIFF
--- a/resources/views/livewire/cache.blade.php
+++ b/resources/views/livewire/cache.blade.php
@@ -1,3 +1,6 @@
+@php
+    use Illuminate\Support\Str;
+@endphp
 <x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
     <x-pulse::card-header
         name="Cache"

--- a/resources/views/livewire/queues.blade.php
+++ b/resources/views/livewire/queues.blade.php
@@ -1,3 +1,6 @@
+@php
+    use Illuminate\Support\Str;
+@endphp
 <x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
     <x-pulse::card-header
         name="Queues"

--- a/resources/views/livewire/slow-outgoing-requests.blade.php
+++ b/resources/views/livewire/slow-outgoing-requests.blade.php
@@ -1,3 +1,6 @@
+@php
+    use Illuminate\Support\Str;
+@endphp
 <x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
     <x-pulse::card-header
         name="Slow Outgoing Requests"


### PR DESCRIPTION
Hello,

On a fresh install, going to `/pulse` results in the following error: https://flareapp.io/share/87nK4ry5

Adding missing use for `Illuminate\Support\Str` in 3 blade views fixed the issue.
