### PR TITLE
[1.x] Allow ignoring route registration

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -83,6 +83,11 @@ class Pulse
     protected bool $runsMigrations = true;
 
     /**
+     * Indicates if Pulse routes will be registered.
+     */
+    protected bool $registersRoutes = true;
+
+    /**
      * Handle exceptions using the given callback.
      *
      * @var ?callable(\Throwable): mixed
@@ -465,6 +470,24 @@ class Pulse
     public function ignoreMigrations(): self
     {
         $this->runsMigrations = false;
+
+        return $this;
+    }
+
+    /**
+     * Determine if Pulse may register routes.
+     */
+    public function registersRoutes(): bool
+    {
+        return $this->registersRoutes;
+    }
+
+    /**
+     * Configure Pulse to not register its routes.
+     */
+    public function ignoreRoutes(): self
+    {
+        $this->registersRoutes = false;
 
         return $this;
     }

--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -96,15 +96,17 @@ class PulseServiceProvider extends ServiceProvider
     protected function registerRoutes(): void
     {
         $this->callAfterResolving('router', function (Router $router, Application $app) {
-            $router->group([
-                'domain' => $app->make('config')->get('pulse.domain', null),
-                'prefix' => $app->make('config')->get('pulse.path'),
-                'middleware' => $app->make('config')->get('pulse.middleware', 'web'),
-            ], function (Router $router) {
-                $router->get('/', function (Pulse $pulse, ViewFactory $view) {
-                    return $view->make('pulse::dashboard');
-                })->name('pulse');
-            });
+            if ($app->make(Pulse::class)->registersRoutes()) {
+                $router->group([
+                    'domain' => $app->make('config')->get('pulse.domain', null),
+                    'prefix' => $app->make('config')->get('pulse.path'),
+                    'middleware' => $app->make('config')->get('pulse.middleware', 'web'),
+                ], function (Router $router) {
+                    $router->get('/', function (Pulse $pulse, ViewFactory $view) {
+                        return $view->make('pulse::dashboard');
+                    })->name('pulse');
+                });
+            }
         });
     }
 


### PR DESCRIPTION
Similiar to other first pary packages i thought it would be great to allow ignoring route registration, in order to be able to register the routes yourself. A more practical use case might be if you use something like tenancy for laravel where registring the routes only on central domains, etc.. can be beneficial and easir to be created that way
