### PR TITLE
[1.x] Make migrations publishable

### DIFF
--- a/src/Facades/Pulse.php
+++ b/src/Facades/Pulse.php
@@ -26,8 +26,6 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Laravel\Pulse\Pulse rememberUser(\Illuminate\Contracts\Auth\Authenticatable $user)
  * @method static string css()
  * @method static string js()
- * @method static bool runsMigrations()
- * @method static \Laravel\Pulse\Pulse ignoreMigrations()
  * @method static bool registersRoutes()
  * @method static \Laravel\Pulse\Pulse ignoreRoutes()
  * @method static \Laravel\Pulse\Pulse handleExceptionsUsing(callable $callback)

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -77,7 +77,6 @@ class Pulse
      */
     protected int|string|null $rememberedUserId = null;
 
-
     /**
      * Indicates if Pulse routes will be registered.
      */
@@ -451,7 +450,6 @@ class Pulse
 
         return $content;
     }
-
 
     /**
      * Determine if Pulse may register routes.

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -77,10 +77,6 @@ class Pulse
      */
     protected int|string|null $rememberedUserId = null;
 
-    /**
-     * Indicates if Pulse migrations will be run.
-     */
-    protected bool $runsMigrations = true;
 
     /**
      * Indicates if Pulse routes will be registered.
@@ -456,23 +452,6 @@ class Pulse
         return $content;
     }
 
-    /**
-     * Determine if Pulse may run migrations.
-     */
-    public function runsMigrations(): bool
-    {
-        return $this->runsMigrations;
-    }
-
-    /**
-     * Configure Pulse to not register its migrations.
-     */
-    public function ignoreMigrations(): self
-    {
-        $this->runsMigrations = false;
-
-        return $this;
-    }
 
     /**
      * Determine if Pulse may register routes.

--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
-use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Routing\Router;
@@ -75,7 +74,6 @@ class PulseServiceProvider extends ServiceProvider
         $this->listenForEvents();
         $this->registerComponents();
         $this->registerResources();
-        $this->registerMigrations();
         $this->registerPublishing();
         $this->registerCommands();
     }
@@ -191,18 +189,6 @@ class PulseServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the package's migrations.
-     */
-    protected function registerMigrations(): void
-    {
-        $this->callAfterResolving('migrator', function (Migrator $migrator, Application $app) {
-            if ($app->make(Pulse::class)->runsMigrations()) {
-                $migrator->path(__DIR__.'/../database/migrations');
-            }
-        });
-    }
-
-    /**
      * Register the package's publishable resources.
      */
     protected function registerPublishing(): void
@@ -218,7 +204,7 @@ class PulseServiceProvider extends ServiceProvider
 
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
-            ], 'pulse-migrations');
+            ], ['pulse', 'pulse-migrations']);
         }
     }
 

--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -215,6 +215,10 @@ class PulseServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../resources/views/dashboard.blade.php' => resource_path('views/vendor/pulse/dashboard.blade.php'),
             ], ['pulse', 'pulse-dashboard']);
+
+            $this->publishes([
+                __DIR__.'/../database/migrations' => database_path('migrations'),
+            ], 'pulse-migrations');
         }
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,7 @@ abstract class TestCase extends OrchestraTestCase
 
     protected function defineDatabaseMigrations(): void
     {
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->loadMigrationsFrom(__DIR__.'/migrations');
     }
 


### PR DESCRIPTION
Similiar to other first pary packages i thought it would be great to allow publishing migrations. Same as in this pr #80: a more practical use case might be if you use something like tenancy for laravel where you might want to have those migrations for your tenant databases as well

