### PR TITLE
Update link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel Pulse is a real-time application performance monitoring tool and dashboa
 
 ## Official Documentation
 
-Documentation for Pulse can be found on the [Laravel website](https://laravel.com/docs).
+Documentation for Pulse can be found on the [Laravel website](https://laravel.com/docs/pulse).
 
 ## Contributing
 


### PR DESCRIPTION
This PR is a minor fix on the link to the README to the docs.

Currently, it's pointing to the general Laravel docs. This links directly to https://laravel.com/docs/pulse.