### PR TITLE
[1.x] Fix file path in SlowQueries.php AND Exceptions.php

### DIFF
--- a/src/Recorders/Exceptions.php
+++ b/src/Recorders/Exceptions.php
@@ -136,6 +136,6 @@ class Exceptions
      */
     protected function formatLocation(string $file, ?int $line): string
     {
-        return Str::replaceFirst(base_path('/'), '', $file).(is_int($line) ? (':'.$line) : '');
+        return Str::replaceFirst(base_path(DIRECTORY_SEPARATOR), '', $file).(is_int($line) ? (':'.$line) : '');
     }
 }

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -96,6 +96,6 @@ class SlowQueries
      */
     protected function formatLocation(string $file, ?int $line): string
     {
-        return Str::replaceFirst(base_path('/'), '', $file).(is_int($line) ? (':'.$line) : '');
+        return Str::replaceFirst(base_path(DIRECTORY_SEPARATOR), '', $file).(is_int($line) ? (':'.$line) : '');
     }
 }

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -85,8 +85,8 @@ class SlowQueries
      */
     protected function isInternalFile(string $file): bool
     {
-        return Str::startsWith($file, base_path('vendor/laravel/pulse'))
-            || Str::startsWith($file, base_path('vendor/laravel/framework'))
+        return Str::startsWith($file, base_path('vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'pulse'))
+            || Str::startsWith($file, base_path('vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'framework'))
             || $file === base_path('artisan')
             || $file === public_path('index.php');
     }


### PR DESCRIPTION
I have windows operating system, it was showing wrong path in both the files.

I replaced the '/' with the `DIRECTORY_SEPARATOR` constant to ensure consistent directory separation across different operating systems.

before

![image](https://github.com/laravel/pulse/assets/53343069/a0651f1f-3b22-4ab2-b31d-27640d514fc6)


after

![image](https://github.com/laravel/pulse/assets/53343069/fb9253b2-5365-47db-a30d-bdebfe369d35)


in Exception

![image](https://github.com/laravel/pulse/assets/53343069/30d4e592-51b8-4426-bfd1-f802b256069f)
