### PR TITLE
Register routes earlier to avoid conflict with fallback routes

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory as ViewFactory;
@@ -95,18 +96,14 @@ class PulseServiceProvider extends ServiceProvider
      */
     protected function registerRoutes(): void
     {
-        $this->app->booted(function () {
-            $this->callAfterResolving('router', function (Router $router, Application $app) {
-                $router->group([
-                    'domain' => $app->make('config')->get('pulse.domain', null),
-                    'prefix' => $app->make('config')->get('pulse.path'),
-                    'middleware' => $app->make('config')->get('pulse.middleware', 'web'),
-                ], function (Router $router) {
-                    $router->get('/', function (Pulse $pulse, ViewFactory $view) {
-                        return $view->make('pulse::dashboard');
-                    })->name('pulse');
-                });
-            });
+        Route::group([
+            'domain' => app()->make('config')->get('pulse.domain', null),
+            'prefix' => app()->make('config')->get('pulse.path'),
+            'middleware' => app()->make('config')->get('pulse.middleware', 'web'),
+        ], function () {
+            Route::get('/', function (Pulse $pulse, ViewFactory $view) {
+                return $view->make('pulse::dashboard');
+            })->name('pulse');
         });
     }
 


### PR DESCRIPTION
Thanks for this package! I'm excited to dig in and I think it's going to be useful on a daily basis.

I have a basic Jetstream app that shortens URLs. To resolve any short URL, I have a route at the bottom of my routes/web.php file:

```php
// Fallback: resolve a link
Route::get('{link:short_url}', [LinkController::class, 'show'])
    ->name('links.show');
```

This fallback URL catches `/pulse` so the `pulse` route doesn't work. However, the Jetstream `/login` route is working just fine, so I dug into how Jetstream registers its routes ([`JetstreamServiceProvider@configureRoutes`](https://github.com/laravel/jetstream/blob/4.x/src/JetstreamServiceProvider.php#L139-L150)) and compared it to how Pulse is doing the same thing.

This PR aligns Pulse with Jetstream's approach and works in my application. I'm not confident it is the best general solution, but thought a PR was more appropriate than an issue to illustrate my problem.

Thanks again! Congrats on the launch!