### PR TITLE
Added IDE projects settings exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.idea
+/.fleet
+/.vscode
 /node_modules
 /public/app.js.LICENSE.txt
 /vendor


### PR DESCRIPTION
Added exceptions for popular IDEs: JetBrains Intellij IDEA (including PhpStorm), JetBrains Fleet and VSCode.

To prevent them from being added to the git repository when creating a commit.