### PR TITLE
Switching engine to InnoDB

### DIFF
--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -21,6 +21,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('pulse_values', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->text('key');
@@ -33,6 +34,7 @@ return new class extends Migration
         });
 
         Schema::create('pulse_entries', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->text('key');
@@ -46,6 +48,7 @@ return new class extends Migration
         });
 
         Schema::create('pulse_aggregates', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
             $table->unsignedInteger('bucket');
             $table->unsignedMediumInteger('period');
             $table->string('type');


### PR DESCRIPTION
Correction of the error that occurs during migration.

` SQLSTATE[HY000]: General error: 1478 Table storage engine 'MyISAM' does not support the create option 'Index on virtual generated column' (Connection: mysql, SQL: alter table pulse_values add unique pulse_values_type_key_hash_unique(type, key_hash))`

This PR close #103