### PR TITLE
Allow recorder inheritance

### DIFF
--- a/src/Recorders/Concerns/Groups.php
+++ b/src/Recorders/Concerns/Groups.php
@@ -9,7 +9,7 @@ trait Groups
      */
     protected function group(string $value): string
     {
-        foreach ($this->config->get('pulse.recorders.'.self::class.'.groups') as $pattern => $replacement) {
+        foreach ($this->config->get('pulse.recorders.'.static::class.'.groups') as $pattern => $replacement) {
             $group = preg_replace($pattern, $replacement, $value, count: $count);
 
             if ($count > 0 && $group !== null) {

--- a/src/Recorders/Concerns/Ignores.php
+++ b/src/Recorders/Concerns/Ignores.php
@@ -10,7 +10,7 @@ trait Ignores
     protected function shouldIgnore(string $value): bool
     {
         // @phpstan-ignore argument.templateType, argument.templateType
-        return collect($this->config->get('pulse.recorders.'.self::class.'.ignore'))
+        return collect($this->config->get('pulse.recorders.'.static::class.'.ignore'))
             ->contains(fn (string $pattern) => preg_match($pattern, $value));
     }
 }

--- a/src/Recorders/Concerns/Sampling.php
+++ b/src/Recorders/Concerns/Sampling.php
@@ -12,7 +12,7 @@ trait Sampling
     protected function shouldSample(): bool
     {
         return Lottery::odds(
-            $this->config->get('pulse.recorders.'.self::class.'.sample_rate')
+            $this->config->get('pulse.recorders.'.static::class.'.sample_rate')
         )->choose();
     }
 
@@ -23,6 +23,6 @@ trait Sampling
     {
         $value = hexdec(md5($seed)) / pow(16, 32); // Scale to 0-1
 
-        return $value <= $this->config->get('pulse.recorders.'.self::class.'.sample_rate');
+        return $value <= $this->config->get('pulse.recorders.'.static::class.'.sample_rate');
     }
 }

--- a/src/Recorders/Concerns/Thresholds.php
+++ b/src/Recorders/Concerns/Thresholds.php
@@ -9,6 +9,6 @@ trait Thresholds
      */
     protected function underThreshold(int|float $duration): bool
     {
-        return $duration < $this->config->get('pulse.recorders.'.self::class.'.threshold');
+        return $duration < $this->config->get('pulse.recorders.'.static::class.'.threshold');
     }
 }

--- a/src/Recorders/Exceptions.php
+++ b/src/Recorders/Exceptions.php
@@ -54,7 +54,7 @@ class Exceptions
                 return;
             }
 
-            $location = $this->config->get('pulse.recorders.'.self::class.'.location')
+            $location = $this->config->get('pulse.recorders.'.static::class.'.location')
                 ? $this->resolveLocation($e)
                 : null;
 

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -39,7 +39,7 @@ class Servers
             return;
         }
 
-        $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
+        $server = $this->config->get('pulse.recorders.'.static::class.'.server_name');
         $slug = Str::slug($server);
 
         $memoryTotal = match (PHP_OS_FAMILY) {
@@ -67,7 +67,7 @@ class Servers
             'cpu' => $cpu,
             'memory_used' => $memoryUsed,
             'memory_total' => $memoryTotal,
-            'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType argument.templateType
+            'storage' => collect($this->config->get('pulse.recorders.'.static::class.'.directories')) // @phpstan-ignore argument.templateType argument.templateType
                 ->map(fn (string $directory) => [
                     'directory' => $directory,
                     'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -41,7 +41,7 @@ class SlowQueries
             CarbonImmutable::now()->getTimestampMs(),
             (int) $event->time,
             $event->sql,
-            $this->config->get('pulse.recorders.'.self::class.'.location')
+            $this->config->get('pulse.recorders.'.static::class.'.location')
                 ? $this->resolveLocation()
                 : null,
         ];


### PR DESCRIPTION
When trying to build a custom recorders which all inherited from a base class I ran into some issues where the config object was resolving values from the base class name, causing the recorder not to run.

Technically only the Concerns need to be updated to fix this, but I've gone ahead and updated the built-in recorders as well so that they can be extended and have their own configs.