### PR TITLE
[1.x] Ensure catch-all routes do not take precedence

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -95,17 +95,15 @@ class PulseServiceProvider extends ServiceProvider
      */
     protected function registerRoutes(): void
     {
-        $this->app->booted(function () {
-            $this->callAfterResolving('router', function (Router $router, Application $app) {
-                $router->group([
-                    'domain' => $app->make('config')->get('pulse.domain', null),
-                    'prefix' => $app->make('config')->get('pulse.path'),
-                    'middleware' => $app->make('config')->get('pulse.middleware', 'web'),
-                ], function (Router $router) {
-                    $router->get('/', function (Pulse $pulse, ViewFactory $view) {
-                        return $view->make('pulse::dashboard');
-                    })->name('pulse');
-                });
+        $this->callAfterResolving('router', function (Router $router, Application $app) {
+            $router->group([
+                'domain' => $app->make('config')->get('pulse.domain', null),
+                'prefix' => $app->make('config')->get('pulse.path'),
+                'middleware' => $app->make('config')->get('pulse.middleware', 'web'),
+            ], function (Router $router) {
+                $router->get('/', function (Pulse $pulse, ViewFactory $view) {
+                    return $view->make('pulse::dashboard');
+                })->name('pulse');
             });
         });
     }


### PR DESCRIPTION
The route registration is currently delayed until the app has `booted`.

This causes catch-all routes to take precedence.

If an app has the following route:

```php
Route::get('{foo}', function () {
    return view('welcome');
});
```

Pulse will not be accessible. This PR fixes that by registering the routes as soon as the router is resolved.