### PR TITLE
[1.x] Fix `isOnlyBuckets` DocComment

### DIFF
--- a/src/Entry.php
+++ b/src/Entry.php
@@ -93,7 +93,7 @@ class Entry
     }
 
     /**
-     * Determine whether the entry is marked for average aggregation.
+     * Determine whether to only save aggregate bucket data for the entry.
      */
     public function isOnlyBuckets(): bool
     {


### PR DESCRIPTION
Small amendment to the DocComment so it accurately reflects what the method does.