### PR TITLE
[1.x] Support DB configurations that _require_ a unique ID

### DIFF
--- a/UPGRADE.MD
+++ b/UPGRADE.MD
@@ -1,0 +1,6 @@
+# Upgrade Guide
+
+# Beta to 1.x
+
+- [Auto-incrementing IDs were added to Pulse's tables](https://github.com/laravel/pulse/pull/142). This is recommend if you are using a configuration that requires tables have a unique key on every table, e.g., PlanetScale.
+

--- a/UPGRADE.MD
+++ b/UPGRADE.MD
@@ -2,5 +2,5 @@
 
 # Beta to 1.x
 
-- [Auto-incrementing IDs were added to Pulse's tables](https://github.com/laravel/pulse/pull/142). This is recommend if you are using a configuration that requires tables have a unique key on every table, e.g., PlanetScale.
+- [Auto-incrementing IDs were added to Pulse's tables](https://github.com/laravel/pulse/pull/142). This is recommended if you are using a configuration that requires tables to have a unique key on every table, e.g., PlanetScale.
 

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -22,6 +22,7 @@ return new class extends Migration
     {
         Schema::create('pulse_values', function (Blueprint $table) {
             $table->engine = 'InnoDB';
+            $table->id();
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->text('key');
@@ -35,6 +36,7 @@ return new class extends Migration
 
         Schema::create('pulse_entries', function (Blueprint $table) {
             $table->engine = 'InnoDB';
+            $table->id();
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->text('key');
@@ -49,6 +51,7 @@ return new class extends Migration
 
         Schema::create('pulse_aggregates', function (Blueprint $table) {
             $table->engine = 'InnoDB';
+            $table->id();
             $table->unsignedInteger('bucket');
             $table->unsignedMediumInteger('period');
             $table->string('type');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -56,7 +56,7 @@ expect()->extend('toContainAggregateForAllPeriods', function (string|array $type
     $this->toBeInstanceOf(Collection::class);
 
     $values = $this->value->each(function (stdClass $value) {
-         unset($value->id);
+        unset($value->id);
     });
 
     $types = (array) $type;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -55,6 +55,10 @@ uses(TestCase::class)
 expect()->extend('toContainAggregateForAllPeriods', function (string|array $type, string $aggregate, string $key, int $value, int $count = null, int $timestamp = null) {
     $this->toBeInstanceOf(Collection::class);
 
+    $values = $this->value->each(function (stdClass $value) {
+         unset($value->id);
+    });
+
     $types = (array) $type;
     $timestamp ??= now()->timestamp;
 


### PR DESCRIPTION
We don't need these, but it seems some DB providers do, such as PlanetScale and DigitalOcean managed DBs.

Fixes https://github.com/laravel/pulse/issues/136, https://github.com/laravel/pulse/issues/108

