### PR TITLE
fix connection returning string

### DIFF
--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -21,7 +21,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $connection = $this->getConnection() ?? DB::connection();
+        $connection = DB::connection($this->getConnection());
 
         Schema::create('pulse_values', function (Blueprint $table) use ($connection) {
             $table->engine = 'InnoDB';


### PR DESCRIPTION
Hi! 

this line is failing `$connection->getDriverName()` when you specify `pulse.storage.database.connection` since it is a string!