### PR TITLE
[1.x] Remove default `web` middleware

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -100,7 +100,7 @@ class PulseServiceProvider extends ServiceProvider
                 $router->group([
                     'domain' => $app->make('config')->get('pulse.domain', null),
                     'prefix' => $app->make('config')->get('pulse.path'),
-                    'middleware' => $app->make('config')->get('pulse.middleware', 'web'),
+                    'middleware' => $app->make('config')->get('pulse.middleware'),
                 ], function (Router $router) {
                     $router->get('/', function (Pulse $pulse, ViewFactory $view) {
                         return $view->make('pulse::dashboard');


### PR DESCRIPTION
We provide sensible default middleware for most applications, but we have hardcoded the `web` middleware as a fallback when there isn't any.

If a user has change their configuration I think we should respect it.

Additionally, not all applications will have a `web` middleware defined, so we can't rely on it as a safe fallback.

Fixes https://github.com/laravel/pulse/issues/146