### PR TITLE
[1.x] Custom card CSS

### DIFF
--- a/resources/views/components/pulse.blade.php
+++ b/resources/views/components/pulse.blade.php
@@ -11,15 +11,11 @@
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:300,400,500,600" rel="stylesheet" />
 
-        <style>
-            {!! Laravel\Pulse\Facades\Pulse::css() !!}
-        </style>
+        {!! Laravel\Pulse\Facades\Pulse::css() !!}
 
         @livewireStyles
 
-        <script>
-            {!! Laravel\Pulse\Facades\Pulse::js() !!}
-        </script>
+        {!! Laravel\Pulse\Facades\Pulse::js() !!}
     </head>
     <body class="font-sans antialiased">
         <div class="bg-gray-50 dark:bg-gray-950 min-h-screen">

--- a/src/Facades/Pulse.php
+++ b/src/Facades/Pulse.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Laravel\Pulse\Pulse resolveAuthenticatedUserIdUsing(callable $callback)
  * @method static mixed|null withUser(\Illuminate\Contracts\Auth\Authenticatable|string|int|null $user, callable $callback)
  * @method static \Laravel\Pulse\Pulse rememberUser(\Illuminate\Contracts\Auth\Authenticatable $user)
- * @method static string css()
+ * @method static string|self css(array|string|null $path = null)
  * @method static string js()
  * @method static bool registersRoutes()
  * @method static \Laravel\Pulse\Pulse ignoreRoutes()

--- a/src/Facades/Pulse.php
+++ b/src/Facades/Pulse.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Laravel\Pulse\Pulse resolveAuthenticatedUserIdUsing(callable $callback)
  * @method static mixed|null withUser(\Illuminate\Contracts\Auth\Authenticatable|string|int|null $user, callable $callback)
  * @method static \Laravel\Pulse\Pulse rememberUser(\Illuminate\Contracts\Auth\Authenticatable $user)
- * @method static string|self css(array|string|null $path = null)
+ * @method static string|self css(array|string|\Illuminate\Contracts\Support\Htmlable|null $path = null)
  * @method static string js()
  * @method static bool registersRoutes()
  * @method static \Laravel\Pulse\Pulse ignoreRoutes()

--- a/src/Livewire/Card.php
+++ b/src/Livewire/Card.php
@@ -48,17 +48,25 @@ abstract class Card extends Component
 
     /**
      * Capture component-specific CSS.
+     *
+     * @return void
      */
-    public function dehydrate(): void
+    public function dehydrate()
     {
         if (Livewire::isLivewireRequest()) {
             return;
         }
 
-        if (! property_exists($this, 'css')) {
-            return;
-        }
+        Pulse::css($this->css());
+    }
 
-        Pulse::css($this->css);
+    /**
+     * Define any CSS that should be loaded for the component.
+     *
+     * @return string|\Illuminate\Contracts\Support\Htmlable|array<int, string|\Illuminate\Contracts\Support\Htmlable>|null
+     */
+    protected function css()
+    {
+        return null;
     }
 }

--- a/src/Livewire/Card.php
+++ b/src/Livewire/Card.php
@@ -4,7 +4,9 @@ namespace Laravel\Pulse\Livewire;
 
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\View;
+use Laravel\Pulse\Facades\Pulse;
 use Livewire\Component;
+use Livewire\Livewire;
 
 abstract class Card extends Component
 {
@@ -42,5 +44,21 @@ abstract class Card extends Component
             'rows' => $this->rows ?? null,
             'class' => $this->class,
         ]);
+    }
+
+    /**
+     * Capture component-specific CSS.
+     */
+    public function dehydrate(): void
+    {
+        if (Livewire::isLivewireRequest()) {
+            return;
+        }
+
+        if (! property_exists($this, 'css')) {
+            return;
+        }
+
+        Pulse::css($this->css);
     }
 }

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -440,7 +440,7 @@ class Pulse
      *
      * @param  string|list<string>|null  $path
      */
-    public function css(string|array $path = null): string|self
+    public function css(string|array|null $path = null): string|self
     {
         if (is_string($path)) {
             $path = [$path];

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -442,7 +442,7 @@ class Pulse
      *
      * @param  string|Htmlable|list<string|Htmlable>|null  $css
      */
-    public function css(string|Htmlable|array $css = null): string|self
+    public function css(string|Htmlable|array|null $css = null): string|self
     {
         if (func_num_args() === 1) {
             $this->css = array_values(array_unique(array_merge($this->css, Arr::wrap($css))));

--- a/tests/Feature/Livewire/CustomCardTest.php
+++ b/tests/Feature/Livewire/CustomCardTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Support\HtmlString;
+use Laravel\Pulse\Facades\Pulse;
+use Laravel\Pulse\Livewire\Card;
+use Livewire\Livewire;
+
+it('loads custom css using a path', function () {
+    Livewire::test(CustomCardWithCssPath::class)
+        ->assertOk();
+
+    $css = Pulse::css();
+
+    expect($css)->toContain(<<<HTML
+        <style>.custom-class {
+            color: purple;
+        }
+        </style>
+        HTML);
+});
+
+it('loads custom css using a Htmlable', function () {
+    Livewire::test(CustomCardWithCssHtmlable::class)
+        ->assertOk();
+
+    $css = Pulse::css();
+
+    expect($css)->toContain('<link rel="stylesheet" src="https://example.com/cdn/custom-card.css">');
+});
+
+class CustomCardWithCssPath extends Card
+{
+    public function render()
+    {
+        return '<div></div>';
+    }
+
+    protected function css()
+    {
+        return __DIR__.'/../../fixtures/custom.css';
+    }
+}
+
+class CustomCardWithCssHtmlable extends Card
+{
+    public function render()
+    {
+        return '<div></div>';
+    }
+
+    protected function css()
+    {
+        return new HtmlString('<link rel="stylesheet" src="https://example.com/cdn/custom-card.css">');
+    }
+}

--- a/tests/Feature/Livewire/CustomCardTest.php
+++ b/tests/Feature/Livewire/CustomCardTest.php
@@ -11,7 +11,7 @@ it('loads custom css using a path', function () {
 
     $css = Pulse::css();
 
-    expect($css)->toContain(<<<HTML
+    expect($css)->toContain(<<<'HTML'
         <style>.custom-class {
             color: purple;
         }

--- a/tests/fixtures/custom.css
+++ b/tests/fixtures/custom.css
@@ -1,0 +1,3 @@
+.custom-class {
+    color: purple;
+}


### PR DESCRIPTION
This PR introduces a way for custom cards to load any CSS they need.

The challenge:

* Blade stacks won't work for "lazy" cards unless the CSS is pushed from the placeholder view rather than the render view.
* Any `<link>` tags directly in the card would require packages to publish CSS to the application's `public` directory, and lazy-loaded cards would have a _flash of unstyled content_ when the card is loaded.
* If a package contains multiple cards sharing a single CSS file, the CSS should only be included on the page once, regardless of how many cards are used.
* If a package contains multiple cards with dedicated CSS files, only the CSS for the cards that are being used should be included on the page.

The solution:

Custom cards can now implement a `css` method when extending the `Card` component, which should return either a CSS file path or an `Htmlable` object. This method will only be called when the card has been included on the dashboard, so packages that ship multiple cards may separate their CSS if they wish, and only the required CSS will be loaded.

```php
class CustomCard extends Card
{
    // ...

    protected function css()
    {
        return __DIR__.'/../../dist/card.css';
    }
}
```

Under the hood, the CSS paths and `Htmlable` objects are passed to the `Pulse::css` method, which will load CSS files from disk (including from the `vendor` directory) and wrap the contents in `<style>` tags. `Htmlable` objects will be output as-is, allowing for CDNs, etc.

Custom cards implemented with Tailwind should avoid including Tailwind's "preflight" styles, and ideally ensure their CSS is scoped to their card by using Tailwind's [`important` selector strategy](https://tailwindcss.com/docs/configuration#selector-strategy). E.g:

```js
export default {
    darkMode: 'class',
    important: '#my-card',
    content: [
        './path/to/my-card.blade.php',
    ],
    corePlugins: {
        preflight: false,
    },
};
```

Custom cards should ensure they add an `id` attribute to their card that matches the name configured in the `important` key above. E.g.

```blade
<x-pulse::card id="my-card" :cols="$cols" :rows="$rows" class="$class">
    ...
</x-pulse::card>
```