### PR TITLE
[1.x] Fix number rounding on cache card

### DIFF
--- a/resources/views/livewire/cache.blade.php
+++ b/resources/views/livewire/cache.blade.php
@@ -58,7 +58,7 @@
                     </div>
                     <div class="flex flex-col justify-center @sm:block">
                         <span class="text-xl uppercase font-bold text-gray-700 dark:text-gray-300 tabular-nums">
-                            {{ round($allCacheInteractions->hits / ($allCacheInteractions->hits + $allCacheInteractions->misses) * 100, 2).'%' }}
+                            {{ ((int) ($allCacheInteractions->hits / ($allCacheInteractions->hits + $allCacheInteractions->misses) * 10000)) / 100 }}%
                         </span>
                         <span class="text-xs uppercase font-bold text-gray-500 dark:text-gray-400">
                             Hit Rate
@@ -105,7 +105,7 @@
                                         @endif
                                     </x-pulse::td>
                                     <x-pulse::td numeric class="text-gray-700 dark:text-gray-300 font-bold">
-                                        {{ round($interaction->hits / ($interaction->hits + $interaction->misses) * 100, 2).'%' }}
+                                        {{ ((int) ($interaction->hits / ($interaction->hits + $interaction->misses) * 10000)) / 100 }}%
                                     </x-pulse::td>
                                 </tr>
                             @endforeach

--- a/tests/Feature/Livewire/CacheTest.php
+++ b/tests/Feature/Livewire/CacheTest.php
@@ -49,3 +49,25 @@ it('renders cache statistics', function () {
             (object) ['key' => 'bar', 'hits' => 2, 'misses' => 2],
         ]));
 });
+
+it('does not round numbers up', function () {
+    for ($i = 0; $i < 20_000; $i++) {
+        Pulse::record('cache_hit', 'foo')->count()->onlyBuckets();
+    }
+    Pulse::record('cache_miss', 'foo')->count()->onlyBuckets();
+    Pulse::store();
+
+    Livewire::test(Cache::class, ['lazy' => false])
+        ->assertDontSeeHtml("100.00%\n")
+        ->assertSeeHtml("99.99%\n");
+});
+
+it('does not show decimals for round numbers', function () {
+    Pulse::record('cache_hit', 'foo')->count()->onlyBuckets();
+    Pulse::record('cache_miss', 'foo')->count()->onlyBuckets();
+    Pulse::store();
+
+    Livewire::test(Cache::class, ['lazy' => false])
+        ->assertDontSeeHtml("50.00%\n")
+        ->assertSeeHtml("50%\n");
+});


### PR DESCRIPTION
Due to how we are handing rounding, we can sometimes show a `100%` hit rate for cache keys, even when there are misses.

This PR removes the use of `round` and just uses `int` casting to trim the decimal without performing any rounding. We maintain 2 decimal places.