### PR TITLE
[1.x] Collect server metrics on Windows

### DIFF
--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -45,14 +45,14 @@ class Servers
         $memoryTotal = match (PHP_OS_FAMILY) {
             'Darwin' => intval(`sysctl hw.memsize | grep -Eo '[0-9]+'` / 1024 / 1024),
             'Linux' => intval(`cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'` / 1024),
-            'Windows' => intval(trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`) / 1024 / 1024),
+            'Windows' => intval(((int) trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`)) / 1024 / 1024),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         $memoryUsed = match (PHP_OS_FAMILY) {
             'Darwin' => $memoryTotal - intval(intval(`vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'`) * intval(`pagesize`) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(`cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'` / 1024), // MB
-            'Windows' => $memoryTotal - intval(trim(`wmic OS get FreePhysicalMemory | more +1`) / 1024), // MB
+            'Windows' => $memoryTotal - intval(((int) trim(`wmic OS get FreePhysicalMemory | more +1`)) / 1024), // MB
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -45,18 +45,21 @@ class Servers
         $memoryTotal = match (PHP_OS_FAMILY) {
             'Darwin' => intval(`sysctl hw.memsize | grep -Eo '[0-9]+'` / 1024 / 1024),
             'Linux' => intval(`cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'` / 1024),
+            'Windows' => intval(trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`) / 1024 / 1024),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         $memoryUsed = match (PHP_OS_FAMILY) {
             'Darwin' => $memoryTotal - intval(intval(`vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'`) * intval(`pagesize`) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(`cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'` / 1024), // MB
+            'Windows' => $memoryTotal - intval(trim(`wmic OS get FreePhysicalMemory | more +1`) / 1024), // MB
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         $cpu = match (PHP_OS_FAMILY) {
             'Darwin' => (int) `top -l 1 | grep -E "^CPU" | tail -1 | awk '{ print $3 + $5 }'`,
             'Linux' => (int) `top -bn1 | grep '%Cpu(s)' | tail -1 | grep -Eo '[0-9]+\.[0-9]+' | head -n 4 | tail -1 | awk '{ print 100 - $1 }'`,
+            'Windows' => (int) trim(`wmic cpu get loadpercentage | more +1`),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 


### PR DESCRIPTION
This PR adds support for collecting CPU and Memory information on Windows, in addition to the existing Linux and macOS support.

It uses the built-in `wmic` (Windows Management Instrumentation Command-line) utility to collect the information, and the built-in `more` command to remove the header line from the result.

This has been tested on Windows 11, but it should work on all other Windows versions commonly in use.