### PR TITLE
[1.x] Resolve the user key via `getKey`

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -338,10 +338,14 @@ class Pulse
     {
         if ($this->usersResolver) {
             return collect(($this->usersResolver)($ids));
-        } elseif (class_exists(\App\Models\User::class)) {
-            return \App\Models\User::whereKey($ids)->get(['id', 'name', 'email']);
-        } elseif (class_exists(\App\User::class)) {
-            return \App\User::whereKey($ids)->get(['id', 'name', 'email']);
+        }
+
+        if (class_exists($class = \App\Models\User::class) || class_exists($class = \App\User::class)) {
+            return $class::whereKey($ids)->get()->map(fn ($user) => [
+                'id' => $user->getKey(),
+                'name' => $user->name,
+                'email' => $user->email,
+            ]);
         }
 
         return $ids->map(fn (string|int $id) => [


### PR DESCRIPTION
If someone has customised the primary key for whatever reason, we will now resolve it correctly with our default user resolver.

This we now do load all columns, unlike the previous implementation that only loaded the 3 required columns. If this is a problem the resolve can always be customized.

Improves situations like: https://github.com/laravel/pulse/issues/162