### PR TITLE
Escape front-end `@`

### DIFF
--- a/resources/views/components/card-header.blade.php
+++ b/resources/views/components/card-header.blade.php
@@ -1,5 +1,5 @@
 @props(['name' => '', 'title' => '', 'details' => null])
-<header class="flex flex-wrap justify-between items-center gap-4 mb-3 @md:mb-6">
+<header class="flex flex-wrap justify-between items-center gap-4 mb-3 @@md:mb-6">
     <div class="flex-1 basis-0 flex-grow-[10000] max-w-full">
         <div class="flex overflow-hidden gap-2 items-start">
             @if (isset($icon))

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -1,6 +1,6 @@
 @props(['cols' => 6, 'rows' => 1])
 <section
-    {{ $attributes->merge(['class' => "@container flex flex-col p-3 sm:p-6 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-xl shadow-sm ring-1 ring-gray-900/5 default:col-span-full default:lg:col-span-{$cols} default:row-span-{$rows}"]) }}
+    {{ $attributes->merge(['class' => "@@container flex flex-col p-3 sm:p-6 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-xl shadow-sm ring-1 ring-gray-900/5 default:col-span-full default:lg:col-span-{$cols} default:row-span-{$rows}"]) }}
     x-data="{
         loading: false,
         init() {

--- a/resources/views/components/placeholder.blade.php
+++ b/resources/views/components/placeholder.blade.php
@@ -1,5 +1,5 @@
 <x-pulse::card :cols="$cols ?? null" :rows="$rows ?? null" :class="$class ?? ''">
-    <div class="h-[30px] flex items-center w-full mb-3 @md:mb-6">
+    <div class="h-[30px] flex items-center w-full mb-3 @@md:mb-6">
         <div class="rounded bg-gray-50 dark:bg-gray-800 h-6 w-1/2 animate-pulse"></div>
     </div>
     <div class="space-y-4 h-56">

--- a/resources/views/components/scroll.blade.php
+++ b/resources/views/components/scroll.blade.php
@@ -20,9 +20,9 @@
             }
         }
     }"
-    {{ $attributes->merge(['class' => '@container/scroll-wrapper flex-grow flex w-full overflow-hidden' . ($expand ? '' : ' basis-56'), ':class' => "loading && 'opacity-25 animate-pulse'"]) }}
+    {{ $attributes->merge(['class' => '@@container/scroll-wrapper flex-grow flex w-full overflow-hidden' . ($expand ? '' : ' basis-56'), ':class' => "loading && 'opacity-25 animate-pulse'"]) }}
 >
-    <div x-ref="content" class="flex-grow basis-full overflow-y-auto" @scroll.debounce.5ms="scroll">
+    <div x-ref="content" class="flex-grow basis-full overflow-y-auto" @@scroll.debounce.5ms="scroll">
         {{ $slot }}
         <div x-ref="fade" class="h-6 origin-bottom fixed bottom-0 left-0 right-0 bg-gradient-to-t from-white dark:from-gray-900 pointer-events-none" wire:ignore></div>
     </div>

--- a/resources/views/components/td.blade.php
+++ b/resources/views/components/td.blade.php
@@ -1,4 +1,4 @@
 @props(['numeric' => false])
-<td {{ $attributes->merge(['class' => 'first:rounded-l-md last:rounded-r-md text-sm bg-gray-50 dark:bg-gray-800/50 first:pl-3 last:pr-3 px-1 @sm:px-3 py-3' . ($numeric ? ' text-right tabular-nums whitespace-nowrap' : '')]) }}>
+<td {{ $attributes->merge(['class' => 'first:rounded-l-md last:rounded-r-md text-sm bg-gray-50 dark:bg-gray-800/50 first:pl-3 last:pr-3 px-1 @@sm:px-3 py-3' . ($numeric ? ' text-right tabular-nums whitespace-nowrap' : '')]) }}>
     {{ $slot }}
 </td>

--- a/resources/views/components/th.blade.php
+++ b/resources/views/components/th.blade.php
@@ -1,3 +1,3 @@
-<th {{ $attributes->merge(['class' => 'text-xs text-gray-500 uppercase py-2 first:pl-3 last:pr-3 px-1 @sm:px-3 default:text-left']) }}>
+<th {{ $attributes->merge(['class' => 'text-xs text-gray-500 uppercase py-2 first:pl-3 last:pr-3 px-1 @@sm:px-3 default:text-left']) }}>
     {{ $slot }}
 </th>

--- a/resources/views/components/theme-switcher.blade.php
+++ b/resources/views/components/theme-switcher.blade.php
@@ -33,28 +33,28 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', set
             setDarkClass()
         },
     }"
-    @click.outside="menu = false"
+    @@click.outside="menu = false"
 >
     <button
         x-cloak
         class="block p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
         :class="theme ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-600 hover:text-gray-500 focus:text-gray-500 dark:hover:text-gray-500 dark:focus:text-gray-500'"
-        @click="menu = ! menu"
+        @@click="menu = ! menu"
     >
         <x-pulse::icons.sun class="block dark:hidden w-5 h-5" />
         <x-pulse::icons.moon class="hidden dark:block w-5 h-5" />
     </button>
 
-    <div x-show="menu" class="z-10 absolute origin-top-right right-0 bg-white dark:bg-gray-800 rounded-md ring-1 ring-gray-900/5 shadow-xl flex flex-col" style="display: none;" @click="menu = false">
-        <button class="flex items-center px-4 py-2 gap-3 hover:bg-gray-100 dark:hover:bg-gray-700" :class="theme === 'light' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'" @click="lightMode()">
+    <div x-show="menu" class="z-10 absolute origin-top-right right-0 bg-white dark:bg-gray-800 rounded-md ring-1 ring-gray-900/5 shadow-xl flex flex-col" style="display: none;" @@click="menu = false">
+        <button class="flex items-center px-4 py-2 gap-3 hover:bg-gray-100 dark:hover:bg-gray-700" :class="theme === 'light' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'" @@click="lightMode()">
             <x-pulse::icons.sun class="w-5 h-5" />
             Light
         </button>
-        <button class="flex items-center px-4 py-2 gap-3 hover:bg-gray-100 dark:hover:bg-gray-700" :class="theme === 'dark' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'" @click="darkMode()">
+        <button class="flex items-center px-4 py-2 gap-3 hover:bg-gray-100 dark:hover:bg-gray-700" :class="theme === 'dark' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'" @@click="darkMode()">
             <x-pulse::icons.moon class="w-5 h-5" />
             Dark
         </button>
-        <button class="flex items-center px-4 py-2 gap-3 hover:bg-gray-100 dark:hover:bg-gray-700" :class="theme === undefined ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'" @click="systemMode()">
+        <button class="flex items-center px-4 py-2 gap-3 hover:bg-gray-100 dark:hover:bg-gray-700" :class="theme === undefined ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'" @@click="systemMode()">
             <x-pulse::icons.computer-desktop class="w-5 h-5" />
             System
         </button>

--- a/resources/views/livewire/cache.blade.php
+++ b/resources/views/livewire/cache.blade.php
@@ -20,7 +20,7 @@
                     Str::plural('group', $count)
                 );
             @endphp
-            <button title="{{ $message }}" @click="alert('{{ str_replace("\n", '\n', $message) }}')">
+            <button title="{{ $message }}" @@click="alert('{{ str_replace("\n", '\n', $message) }}')">
                 <x-pulse::icons.information-circle class="w-5 h-5 stroke-gray-400 dark:stroke-gray-600" />
             </button>
         </x-slot:actions>
@@ -32,7 +32,7 @@
         @else
             <div class="flex flex-col gap-6">
                 <div class="grid grid-cols-3 gap-3 text-center">
-                    <div class="flex flex-col justify-center @sm:block">
+                    <div class="flex flex-col justify-center @@sm:block">
                         <span class="text-xl uppercase font-bold text-gray-700 dark:text-gray-300 tabular-nums">
                             @if ($config['sample_rate'] < 1)
                                 <span title="Sample rate: {{ $config['sample_rate'] }}, Raw value: {{ number_format($allCacheInteractions->hits) }}">~{{ number_format($allCacheInteractions->hits * (1 / $config['sample_rate'])) }}</span>
@@ -44,7 +44,7 @@
                             Hits
                         </span>
                     </div>
-                    <div class="flex flex-col justify-center @sm:block">
+                    <div class="flex flex-col justify-center @@sm:block">
                         <span class="text-xl uppercase font-bold text-gray-700 dark:text-gray-300 tabular-nums">
                             @if ($config['sample_rate'] < 1)
                                 <span title="Sample rate: {{ $config['sample_rate'] }}, Raw value: {{ number_format($allCacheInteractions->misses) }}">~{{ number_format(($allCacheInteractions->misses) * (1 / $config['sample_rate'])) }}</span>
@@ -56,7 +56,7 @@
                             Misses
                         </span>
                     </div>
-                    <div class="flex flex-col justify-center @sm:block">
+                    <div class="flex flex-col justify-center @@sm:block">
                         <span class="text-xl uppercase font-bold text-gray-700 dark:text-gray-300 tabular-nums">
                             {{ round($allCacheInteractions->hits / ($allCacheInteractions->hits + $allCacheInteractions->misses) * 100, 2).'%' }}
                         </span>

--- a/resources/views/livewire/exceptions.blade.php
+++ b/resources/views/livewire/exceptions.blade.php
@@ -15,7 +15,7 @@
                     'count' => 'count',
                     'latest' => 'latest',
                 ]"
-                @change="loading = true"
+                @@change="loading = true"
             />
         </x-slot:actions>
     </x-pulse::card-header>

--- a/resources/views/livewire/period-selector.blade.php
+++ b/resources/views/livewire/period-selector.blade.php
@@ -12,8 +12,8 @@
         }
     }"
 >
-    <button @click="setPeriod('1_hour')" class="p-1 font-semibold sm:text-lg {{ $period === '1_hour' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">1h</button>
-    <button @click="setPeriod('6_hours')" class="p-1 font-semibold sm:text-lg {{ $period === '6_hours' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">6h</button>
-    <button @click="setPeriod('24_hours')" class="p-1 font-semibold sm:text-lg {{ $period === '24_hours' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">24h</button>
-    <button @click="setPeriod('7_days')" class="p-1 font-semibold sm:text-lg {{ $period === '7_days' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">7d</button>
+    <button @@click="setPeriod('1_hour')" class="p-1 font-semibold sm:text-lg {{ $period === '1_hour' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">1h</button>
+    <button @@click="setPeriod('6_hours')" class="p-1 font-semibold sm:text-lg {{ $period === '6_hours' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">6h</button>
+    <button @@click="setPeriod('24_hours')" class="p-1 font-semibold sm:text-lg {{ $period === '24_hours' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">24h</button>
+    <button @@click="setPeriod('7_days')" class="p-1 font-semibold sm:text-lg {{ $period === '7_days' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">7d</button>
 </div>

--- a/resources/views/livewire/slow-jobs.blade.php
+++ b/resources/views/livewire/slow-jobs.blade.php
@@ -15,7 +15,7 @@
                     'slowest' => 'slowest',
                     'count' => 'count',
                 ]"
-                @change="loading = true"
+                @@change="loading = true"
             />
         </x-slot:actions>
     </x-pulse::card-header>

--- a/resources/views/livewire/slow-outgoing-requests.blade.php
+++ b/resources/views/livewire/slow-outgoing-requests.blade.php
@@ -20,7 +20,7 @@
                     Str::plural('group', $count)
                 );
             @endphp
-            <button title="{{ $message }}" @click="alert('{{ str_replace("\n", '\n', $message) }}')">
+            <button title="{{ $message }}" @@click="alert('{{ str_replace("\n", '\n', $message) }}')">
                 <x-pulse::icons.information-circle class="w-5 h-5 stroke-gray-400 dark:stroke-gray-600" />
             </button>
 
@@ -31,7 +31,7 @@
                     'slowest' => 'slowest',
                     'count' => 'count',
                 ]"
-                @change="loading = true"
+                @@change="loading = true"
             />
         </x-slot:actions>
     </x-pulse::card-header>

--- a/resources/views/livewire/slow-queries.blade.php
+++ b/resources/views/livewire/slow-queries.blade.php
@@ -31,7 +31,7 @@ $sqlFormatter = new SqlFormatter(new HtmlHighlighter([
                     'slowest' => 'slowest',
                     'count' => 'count',
                 ]"
-                @change="loading = true"
+                @@change="loading = true"
             />
         </x-slot:actions>
     </x-pulse::card-header>

--- a/resources/views/livewire/slow-requests.blade.php
+++ b/resources/views/livewire/slow-requests.blade.php
@@ -15,7 +15,7 @@
                     'slowest' => 'slowest',
                     'count' => 'count',
                 ]"
-                @change="loading = true"
+                @@change="loading = true"
             />
         </x-slot:actions>
     </x-pulse::card-header>

--- a/resources/views/livewire/usage.blade.php
+++ b/resources/views/livewire/usage.blade.php
@@ -28,7 +28,7 @@
                         'jobs' => 'dispatching jobs',
                     ]"
                     class="flex-1"
-                    @change="loading = true"
+                    @@change="loading = true"
                 />
             @endif
         </x-slot:actions>
@@ -38,7 +38,7 @@
         @if ($userRequestCounts->isEmpty())
             <x-pulse::no-results />
         @else
-            <div class="grid grid-cols-1 @lg:grid-cols-2 @3xl:grid-cols-3 @6xl:grid-cols-4 gap-2">
+            <div class="grid grid-cols-1 @@lg:grid-cols-2 @3xl:grid-cols-3 @6xl:grid-cols-4 gap-2">
                 @foreach ($userRequestCounts as $userRequestCount)
                     <x-pulse::user-card wire:key="{{ $userRequestCount->user->id }}" :name="$userRequestCount->user->name" :extra="$userRequestCount->user->extra">
                         @if ($userRequestCount->user->avatar ?? false)


### PR DESCRIPTION
Ensures all front end `@` symbols are escaped so Blade doesn't try to parse them as directives.

Fixes issues such as https://github.com/laravel/pulse/issues/148