### PR TITLE
[1.x] Ensure values always contain an integer

### DIFF
--- a/src/Livewire/Cache.php
+++ b/src/Livewire/Cache.php
@@ -42,8 +42,8 @@ class Cache extends Card
                 ->map(function ($row) {
                     return (object) [
                         'key' => $row->key,
-                        'hits' => $row->cache_hit,
-                        'misses' => $row->cache_miss,
+                        'hits' => $row->cache_hit ?? 0,
+                        'misses' => $row->cache_miss ?? 0,
                     ];
                 }),
             'keys'


### PR DESCRIPTION
Fixes a deprecation notice and also just creates an expected value.

Fixes https://github.com/laravel/pulse/issues/166