### PR TITLE
[1.x] Add the ability to disable SQL highlighting

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -194,6 +194,7 @@ return [
             'sample_rate' => env('PULSE_SLOW_QUERIES_SAMPLE_RATE', 1),
             'threshold' => env('PULSE_SLOW_QUERIES_THRESHOLD', 1000),
             'location' => env('PULSE_SLOW_QUERIES_LOCATION', true),
+            'highlighting' => env('PULSE_SLOW_QUERIES_HIGHLIGHTING', true),
             'ignore' => [
                 '/(["`])pulse_[\w]+?\1/', // Pulse tables...
             ],

--- a/resources/views/livewire/slow-queries.blade.php
+++ b/resources/views/livewire/slow-queries.blade.php
@@ -2,17 +2,19 @@
 use \Doctrine\SqlFormatter\HtmlHighlighter;
 use \Doctrine\SqlFormatter\SqlFormatter;
 
-$sqlFormatter = new SqlFormatter(new HtmlHighlighter([
-    HtmlHighlighter::HIGHLIGHT_RESERVED => 'class="font-semibold"',
-    HtmlHighlighter::HIGHLIGHT_QUOTE => 'class="text-purple-200"',
-    HtmlHighlighter::HIGHLIGHT_BACKTICK_QUOTE => 'class="text-purple-200"',
-    HtmlHighlighter::HIGHLIGHT_BOUNDARY => 'class="text-cyan-200"',
-    HtmlHighlighter::HIGHLIGHT_NUMBER => 'class="text-orange-200"',
-    HtmlHighlighter::HIGHLIGHT_WORD => 'class="text-orange-200"',
-    HtmlHighlighter::HIGHLIGHT_VARIABLE => 'class="text-orange-200"',
-    HtmlHighlighter::HIGHLIGHT_ERROR => 'class="text-red-200"',
-    HtmlHighlighter::HIGHLIGHT_COMMENT => 'class="text-gray-400"',
-], false));
+if ($config['highlighting']) {
+    $sqlFormatter = new SqlFormatter(new HtmlHighlighter([
+        HtmlHighlighter::HIGHLIGHT_RESERVED => 'class="font-semibold"',
+        HtmlHighlighter::HIGHLIGHT_QUOTE => 'class="text-purple-200"',
+        HtmlHighlighter::HIGHLIGHT_BACKTICK_QUOTE => 'class="text-purple-200"',
+        HtmlHighlighter::HIGHLIGHT_BOUNDARY => 'class="text-cyan-200"',
+        HtmlHighlighter::HIGHLIGHT_NUMBER => 'class="text-orange-200"',
+        HtmlHighlighter::HIGHLIGHT_WORD => 'class="text-orange-200"',
+        HtmlHighlighter::HIGHLIGHT_VARIABLE => 'class="text-orange-200"',
+        HtmlHighlighter::HIGHLIGHT_ERROR => 'class="text-red-200"',
+        HtmlHighlighter::HIGHLIGHT_COMMENT => 'class="text-gray-400"',
+    ], false));
+}
 @endphp
 <x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
     <x-pulse::card-header
@@ -60,7 +62,7 @@ $sqlFormatter = new SqlFormatter(new HtmlHighlighter([
                             <x-pulse::td class="!p-0 truncate max-w-[1px]">
                                 <div class="relative">
                                     <div class="bg-gray-700 dark:bg-gray-800 py-4 rounded-md text-gray-100 block text-xs whitespace-nowrap overflow-x-auto [scrollbar-color:theme(colors.gray.500)_transparent] [scrollbar-width:thin]">
-                                        <code class="px-3">{!! $sqlFormatter->highlight($query->sql) !!}</code>
+                                        <code class="px-3">{!! $config['highlighting'] ? $sqlFormatter->highlight($query->sql) : $query->sql !!}</code>
                                         @if ($query->location)
                                             <p class="px-3 mt-3 text-xs leading-none text-gray-400 dark:text-gray-500">
                                                 {{ $query->location }}

--- a/src/Livewire/SlowQueries.php
+++ b/src/Livewire/SlowQueries.php
@@ -56,7 +56,10 @@ class SlowQueries extends Card
         return View::make('pulse::livewire.slow-queries', [
             'time' => $time,
             'runAt' => $runAt,
-            'config' => Config::get('pulse.recorders.'.SlowQueriesRecorder::class),
+            'config' => [
+                'highlighting' => true,
+                ...Config::get('pulse.recorders.'.SlowQueriesRecorder::class),
+            ],
             'slowQueries' => $slowQueries,
         ]);
     }


### PR DESCRIPTION
Some SQL queries being captured are rather long, as seen in https://github.com/laravel/pulse/issues/167 where the query overflows the TEXT column.

We've also seen some performance issues in the browser, likely due to syntax highlighting: https://github.com/laravel/pulse/issues/160

This adds a flag to disable syntax highlighting of SQL queries on the fly.