### PR TITLE
[1.x] Improve enabled flag

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -36,10 +36,6 @@ class PulseServiceProvider extends ServiceProvider
             __DIR__.'/../config/pulse.php', 'pulse'
         );
 
-        if (! $this->app->make('config')->get('pulse.enabled')) {
-            return;
-        }
-
         $this->app->singleton(Pulse::class);
         $this->app->bind(Storage::class, DatabaseStorage::class);
 
@@ -63,15 +59,15 @@ class PulseServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if (! $this->app->make('config')->get('pulse.enabled')) {
-            return;
+        if ($enabled = $this->app->make('config')->get('pulse.enabled')) {
+            $this->app->make(Pulse::class)->register($this->app->make('config')->get('pulse.recorders'));
+            $this->listenForEvents();
+        } else {
+            $this->app->make(Pulse::class)->stopRecording();
         }
-
-        $this->app->make(Pulse::class)->register($this->app->make('config')->get('pulse.recorders'));
 
         $this->registerAuthorization();
         $this->registerRoutes();
-        $this->listenForEvents();
         $this->registerComponents();
         $this->registerResources();
         $this->registerPublishing();


### PR DESCRIPTION
Currently, if you "disable" Pulse it acts as if you never installed it.

- No events are registered
- The dashboard is not accessible
- The commands are not accessible
- The pulse class is not registered as a singleton
etc.


This might seem like a good idea, but i think it is more problematic.

Imagine you are running Pulse and you are having troubles. You decide to "disable" pulse and redeploy your application.

If you had `php artisan pulse:restart` in your deploy script, you deployment just broke because we don't register that command any more.

I think that the enabled switch should really only impact the recorders. We already document that this is what the flag does.

<img width="749" alt="Screenshot 2023-12-07 at 2 06 36 pm" src="https://github.com/laravel/pulse/assets/24803032/2150c0c6-68fb-4310-8f28-7e2c83316115">

## Question

One question I do have, though, is if the `pulse:work` command and `pulse:check` command should first look to see if pulse is enabled before starting?