### PR TITLE
Allow for application testing using SQLite

### DIFF
--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -31,7 +31,7 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
+                default => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->text('value');
 
@@ -48,7 +48,7 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
+                default => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->bigInteger('value')->nullable();
 
@@ -67,7 +67,7 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
+                default => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->string('aggregate');
             $table->decimal('value', 20, 2);

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -31,7 +31,8 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                default => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
+                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}].")
+                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->text('value');
 
@@ -48,7 +49,8 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                default => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
+                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}].")
+                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->bigInteger('value')->nullable();
 
@@ -67,7 +69,8 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                default => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
+                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}].")
+                default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->string('aggregate');
             $table->decimal('value', 20, 2);

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -31,7 +31,7 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}].")
+                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->text('value');
@@ -49,7 +49,7 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}].")
+                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->bigInteger('value')->nullable();
@@ -69,7 +69,7 @@ return new class extends Migration
             match ($driver = $connection->getDriverName()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
-                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}].")
+                'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
                 default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
             };
             $table->string('aggregate');


### PR DESCRIPTION
Issue https://github.com/laravel/pulse/issues/177

Laravel Pulse doesn't support SQLite.

It is common to use SQLite whilst running tests of an application built using Laravel.

Pulse's migration throws an error if the database driver is SQLite, causing application tests to fail.

This pull request adds an `App::environment('testing')` check which allows SQLite during testing. Running the migration in any other environment will throw the original exception.

Here is the modified code:

```php
match ($driver = $connection->getDriverName()) {
    'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
    'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
    'sqlite' => App::environment('testing') ? $table->char('key_hash', 16) : throw new RuntimeException("Unsupported database driver [{$driver}]."),
    default => throw new RuntimeException("Unsupported database driver [{$driver}]."),
};
```