### PR TITLE
[1.x] Fix avatar size

### DIFF
--- a/resources/views/livewire/usage.blade.php
+++ b/resources/views/livewire/usage.blade.php
@@ -43,7 +43,7 @@
                     <x-pulse::user-card wire:key="{{ $userRequestCount->user->id }}" :name="$userRequestCount->user->name" :extra="$userRequestCount->user->extra">
                         @if ($userRequestCount->user->avatar ?? false)
                             <x-slot:avatar>
-                                <img src="{{ $userRequestCount->user->avatar }}" loading="lazy" class="rounded-full w-8 h-8">
+                                <img src="{{ $userRequestCount->user->avatar }}" loading="lazy" class="rounded-full w-8 h-8 object-cover">
                             </x-slot:avatar>
                         @endif
 

--- a/resources/views/livewire/usage.blade.php
+++ b/resources/views/livewire/usage.blade.php
@@ -43,7 +43,7 @@
                     <x-pulse::user-card wire:key="{{ $userRequestCount->user->id }}" :name="$userRequestCount->user->name" :extra="$userRequestCount->user->extra">
                         @if ($userRequestCount->user->avatar ?? false)
                             <x-slot:avatar>
-                                <img height="32" width="32" src="{{ $userRequestCount->user->avatar }}" loading="lazy" class="rounded-full">
+                                <img src="{{ $userRequestCount->user->avatar }}" loading="lazy" class="rounded-full w-8 h-8">
                             </x-slot:avatar>
                         @endif
 


### PR DESCRIPTION
Before | After
:-------------------------:|:-------------------------:
![Before](https://github.com/laravel/pulse/assets/121197517/a24c3b42-3e74-4c09-b822-bc1c096ad339)  |  ![After](https://github.com/laravel/pulse/assets/121197517/cdfdb695-d51c-478e-b36c-3561645c51a5)

### PS: This problem seems only to occur when the image dimensions is not equal e.g. 3840x2400.