### PR TITLE
Prevent running migration on sqlite when testing

### DIFF
--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -23,6 +23,10 @@ return new class extends Migration
     {
         $connection = DB::connection($this->getConnection());
 
+        if ('sqlite' === $connection->getDriverName()) {
+            return;
+        }
+
         Schema::create('pulse_values', function (Blueprint $table) use ($connection) {
             $table->id();
             $table->unsignedInteger('timestamp');


### PR DESCRIPTION
To prevent this on test:

```
RuntimeException: Unsupported database driver [sqlite]. in /home/runner/work/laravel-filament-ecommerce/laravel-filament-ecommerce/database/migrations/2023_06_07_000001_create_pulse_tables.php:36
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
