### PR TITLE
[1.x] Add new EntryRecorded Event

### DIFF
--- a/src/Events/EntryRecorded.php
+++ b/src/Events/EntryRecorded.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Pulse\Events;
+
+use Laravel\Pulse\Entry;
+
+class EntryRecorded
+{
+    public function __construct(public Entry $entry)
+    {
+        //
+    }
+}

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Laravel\Pulse\Contracts\Ingest;
 use Laravel\Pulse\Contracts\Storage;
+use Laravel\Pulse\Events\EntryRecorded;
 use Laravel\Pulse\Events\ExceptionReported;
 use RuntimeException;
 use Throwable;
@@ -170,6 +171,8 @@ class Pulse
 
         if ($this->shouldRecord) {
             $this->entries[] = $entry;
+
+            $this->rescue(fn () => $this->app->make('events')->dispatch(new EntryRecorded($entry)));
         }
 
         return $entry;


### PR DESCRIPTION
## Description

This PR introduces the `EntryRecorded` event to the Pulse package, offering developers an easy way to handle and respond to the creation of Pulse Entries.

## Use Cases

- **Real-Time Monitoring**: Facilitates tracking of Pulse Entries in real-time.
- **Custom Alerts**: Developers can set up alerts for exceeding specific thresholds, like request durations, enhancing application performance monitoring.

## Assurance of Non-Breaking Changes

- The addition is a small, backward-compatible enhancement designed to leave existing functionalities intact.

## Note on Testing

- Specific tests for the `EntryRecorded` event are not included as it leverages core Laravel functionality for dispatching events, which is already well-tested and reliable. If mandatory I can add tests of course.