### PR TITLE
[1.x] Allow configurable trim length

### DIFF
--- a/UPGRADE.MD
+++ b/UPGRADE.MD
@@ -4,7 +4,9 @@
 
 ## Required
 
-- [Added a `highlight` configuration option to `pulse.recorders.SlowQueries` configuration block](https://github.com/laravel/pulse/pull/185).
+- [Added a `pulse.recorders.SlowQueries.highlight` configuration option](https://github.com/laravel/pulse/pull/185). You should update your configuration to match.
+- [`pulse.ingest.trim_lottery` configuration key was renamed to `pulse.ingest.trim.lottery`](https://github.com/laravel/pulse/pull/184). You should update your configuration to match.
+- [Added a `pulse.ingest.trim.keep` configuration option](https://github.com/laravel/pulse/pull/184). You should update your configuration to match.
 
 ## Optional
 

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -78,7 +78,10 @@ return [
     'ingest' => [
         'driver' => env('PULSE_INGEST_DRIVER', 'storage'),
 
-        'trim_lottery' => [1, 1_000],
+        'trim' => [
+            'lottery' => [1, 1_000],
+            'keep' => '7 days',
+        ],
 
         'redis' => [
             'connection' => env('PULSE_REDIS_CONNECTION'),

--- a/src/Livewire/SlowQueries.php
+++ b/src/Livewire/SlowQueries.php
@@ -57,6 +57,7 @@ class SlowQueries extends Card
             'time' => $time,
             'runAt' => $runAt,
             'config' => [
+                // TODO remove fallback when tagging v1
                 'highlighting' => true,
                 ...Config::get('pulse.recorders.'.SlowQueriesRecorder::class),
             ],

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -297,6 +297,7 @@ class Pulse
             $this->entries->filter($this->shouldRecord(...)),
         ));
 
+        // TODO remove fallback when tagging v1
         $odds = $this->app->make('config')->get('pulse.ingest.trim.lottery') ?? $this->app->make('config')->get('pulse.ingest.trim_lottery');
 
         Lottery::odds(...$odds)

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -297,7 +297,9 @@ class Pulse
             $this->entries->filter($this->shouldRecord(...)),
         ));
 
-        Lottery::odds(...$this->app->make('config')->get('pulse.ingest.trim_lottery'))
+        $odds = $this->app->make('config')->get('pulse.ingest.trim.lottery') ?? $this->app->make('config')->get('pulse.ingest.trim_lottery');
+
+        Lottery::odds(...$odds)
             ->winner(fn () => $this->rescue($ingest->trim(...)))
             ->choose();
 

--- a/tests/Feature/RedisTest.php
+++ b/tests/Feature/RedisTest.php
@@ -32,13 +32,33 @@ it('runs the same commands while ingesting entries', function ($driver) {
     expect($commands)->toContain('"XADD" "laravel_database_laravel:pulse:ingest" "*" "data" "O:19:\"Laravel\\\\Pulse\\\\Entry\\":6:{s:15:\"\x00*\x00aggregations\";a:0:{}s:14:\"\x00*\x00onlyBuckets\";b:0;s:9:\"timestamp\";i:1700752211;s:4:\"type\";s:3:\"foo\";s:3:\"key\";s:3:\"bar\";s:5:\"value\";i:123;}"');
 })->with(['predis', 'phpredis']);
 
-it('runs the same commands while triming the stream', function ($driver) {
+it('keeps 7 days of data, by default, when trimming', function ($driver) {
     Config::set('database.redis.client', $driver);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
 
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
 
     expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MINID" "~" "946177445000"');
+})->with(['predis', 'phpredis']);
+
+it('can configure days of data to keep when trimming', function ($driver) {
+    Config::set('database.redis.client', $driver);
+    Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
+    Config::set('pulse.ingest.trim.keep', '1 day');
+
+    $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
+
+    expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MINID" "~" "946695845000"');
+})->with(['predis', 'phpredis']);
+
+it('can configure the number of entries to keep when trimming', function ($driver) {
+    Config::set('database.redis.client', $driver);
+    Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
+    Config::set('pulse.ingest.trim.keep', 54321);
+
+    $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
+
+    expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MAXLEN" "~" "54321"');
 })->with(['predis', 'phpredis']);
 
 it('runs the same commands while storing', function ($driver) {


### PR DESCRIPTION
If the `pulse:work` command fails the Ingest will continue to build up in size.

With Redis this is problematic as it is keeping itself in memory. When the `pulse:work` command fails we already trim the ingest on a lottery whenever we put data into the ingest, but it will always retain 7 days worth of data.

That could be problematic for some application depending on their traffic size.

This PR allows the maximum retention for the ingest to be configured.

This value is respected whenever the ingest is trimmed, so it is not guaranteed that the ingest will only contain the configured value until trimming occurs, which again, may happen on a lottery basis.

You may specifiy either a time period or a number of entries to retain.

```php
    // ...

    'ingest' => [
        'trim' => [
            // Keep an interval...
            'keep' => '7 days',
            'keep' => '3 days',
            'keep' => '1 day',
            'keep' => '1 hour',

            // Keep a count of entries...
            'keep' => 500_000,
            'lottery' => [1, 1_000],
        ],
    ],
    
    // ...
```