### PR TITLE
[1.x] Add "sum" and "min" aggregations

### DIFF
--- a/src/Contracts/Storage.php
+++ b/src/Contracts/Storage.php
@@ -49,6 +49,7 @@ interface Storage
      * Retrieve aggregate values for plotting on a graph.
      *
      * @param  list<string>  $types
+     * @param  'count'|'min'|'max'|'sum'|'avg'  $aggregate
      * @return \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<string, int|null>>>
      */
     public function graph(array $types, string $aggregate, CarbonInterval $interval): Collection;
@@ -56,9 +57,10 @@ interface Storage
     /**
      * Retrieve aggregate values for the given type.
      *
-     * @param  list<string>  $aggregates
+     * @param  'count'|'min'|'max'|'sum'|'avg'|list<'count'|'min'|'max'|'sum'|'avg'>  $aggregates
      * @return \Illuminate\Support\Collection<int, object{
      *     key: string,
+     *     min?: int,
      *     max?: int,
      *     sum?: int,
      *     avg?: int,
@@ -78,6 +80,7 @@ interface Storage
      * Retrieve aggregate values for the given types.
      *
      * @param  string|list<string>  $types
+     * @param  'count'|'min'|'max'|'sum'|'avg'  $aggregate
      * @return \Illuminate\Support\Collection<int, object>
      */
     public function aggregateTypes(
@@ -93,6 +96,7 @@ interface Storage
      * Retrieve an aggregate total for the given types.
      *
      * @param  string|list<string>  $types
+     * @param  'count'|'min'|'max'|'sum'|'avg'  $aggregate
      * @return \Illuminate\Support\Collection<string, int>
      */
     public function aggregateTotal(

--- a/src/Entry.php
+++ b/src/Entry.php
@@ -7,7 +7,7 @@ class Entry
     /**
      * The aggregations to perform on the entry.
      *
-     * @var list<'count'|'max'|'sum'|'avg'>
+     * @var list<'count'|'min'|'max'|'sum'|'avg'>
      */
     protected array $aggregations = [];
 
@@ -34,6 +34,16 @@ class Entry
     public function count(): static
     {
         $this->aggregations[] = 'count';
+
+        return $this;
+    }
+
+    /**
+     * Capture the minimum aggregate.
+     */
+    public function min(): static
+    {
+        $this->aggregations[] = 'min';
 
         return $this;
     }
@@ -81,7 +91,7 @@ class Entry
     /**
      * Return the aggregations for the entry.
      *
-     * @return list<'count'|'max'|'sum'|'avg'>
+     * @return list<'count'|'min'|'max'|'sum'|'avg'>
      */
     public function aggregations(): array
     {
@@ -94,6 +104,14 @@ class Entry
     public function isCount(): bool
     {
         return in_array('count', $this->aggregations);
+    }
+
+    /**
+     * Determine whether the entry is marked for minimum aggregation.
+     */
+    public function isMin(): bool
+    {
+        return in_array('min', $this->aggregations);
     }
 
     /**

--- a/src/Entry.php
+++ b/src/Entry.php
@@ -69,6 +69,14 @@ class Entry
     }
 
     /**
+     * Return the aggregations for the entry.
+     */
+    public function aggregations(): array
+    {
+        return $this->aggregations;
+    }
+
+    /**
      * Determine whether the entry is marked for count aggregation.
      */
     public function isCount(): bool

--- a/src/Entry.php
+++ b/src/Entry.php
@@ -7,7 +7,7 @@ class Entry
     /**
      * The aggregations to perform on the entry.
      *
-     * @var list<'count'|'max'|'avg'>
+     * @var list<'count'|'max'|'sum'|'avg'>
      */
     protected array $aggregations = [];
 
@@ -49,6 +49,16 @@ class Entry
     }
 
     /**
+     * Capture the sum aggregate.
+     */
+    public function sum(): static
+    {
+        $this->aggregations[] = 'sum';
+
+        return $this;
+    }
+
+    /**
      * Capture the average aggregate.
      */
     public function avg(): static
@@ -70,6 +80,8 @@ class Entry
 
     /**
      * Return the aggregations for the entry.
+     *
+     * @return list<'count'|'max'|'sum'|'avg'>
      */
     public function aggregations(): array
     {
@@ -90,6 +102,14 @@ class Entry
     public function isMax(): bool
     {
         return in_array('max', $this->aggregations);
+    }
+
+    /**
+     * Determine whether the entry is marked for sum aggregation.
+     */
+    public function isSum(): bool
+    {
+        return in_array('sum', $this->aggregations);
     }
 
     /**

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\DB;
 use Laravel\Pulse\Facades\Pulse;
 
 test('aggregation', function () {
-    Pulse::record('type', 'key1', 200)->count()->max()->sum()->avg();
-    Pulse::record('type', 'key1', 100)->count()->max()->sum()->avg();
-    Pulse::record('type', 'key2', 400)->count()->max()->sum()->avg();
+    Pulse::record('type', 'key1', 200)->count()->min()->max()->sum()->avg();
+    Pulse::record('type', 'key1', 100)->count()->min()->max()->sum()->avg();
+    Pulse::record('type', 'key2', 400)->count()->min()->max()->sum()->avg();
     Pulse::store();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->orderBy('id')->get());
@@ -18,41 +18,52 @@ test('aggregation', function () {
     expect($entries[2])->toHaveProperties(['type' => 'type', 'key' => 'key2', 'value' => 400]);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->orderBy('aggregate')->orderBy('key')->get());
-    expect($aggregates)->toHaveCount(32); // 2 entries * 4 aggregates * 4 periods
+    expect($aggregates)->toHaveCount(40); // 2 entries * 5 aggregates * 4 periods
     expect($aggregates[0])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
     expect($aggregates[1])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
     expect($aggregates[2])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
     expect($aggregates[3])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
     expect($aggregates[4])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
     expect($aggregates[5])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[6])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
-    expect($aggregates[7])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[8])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
-    expect($aggregates[9])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[10])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
-    expect($aggregates[11])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
-    expect($aggregates[12])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
-    expect($aggregates[13])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[14])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
-    expect($aggregates[15])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[16])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
-    expect($aggregates[17])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[18])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
-    expect($aggregates[19])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
-    expect($aggregates[20])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
-    expect($aggregates[21])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[22])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
-    expect($aggregates[23])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[24])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
-    expect($aggregates[25])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[26])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
-    expect($aggregates[27])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
-    expect($aggregates[28])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
-    expect($aggregates[29])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[30])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
-    expect($aggregates[31])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[6])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[7])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[8])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[9])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
 
-    Pulse::record('type', 'key1', 600)->count()->max()->sum()->avg();
+    expect($aggregates[10])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
+    expect($aggregates[11])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[12])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
+    expect($aggregates[13])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[14])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
+    expect($aggregates[15])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[16])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[17])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[18])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[19])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+
+    expect($aggregates[20])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
+    expect($aggregates[21])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[22])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
+    expect($aggregates[23])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[24])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
+    expect($aggregates[25])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[26])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[27])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[28])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[29])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+
+    expect($aggregates[30])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
+    expect($aggregates[31])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[32])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
+    expect($aggregates[33])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[34])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
+    expect($aggregates[35])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[36])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[37])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[38])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[39])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+
+    Pulse::record('type', 'key1', 600)->count()->min()->max()->sum()->avg();
     Pulse::store();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->orderBy('id')->get());
@@ -63,39 +74,50 @@ test('aggregation', function () {
     expect($entries[3])->toHaveProperties(['type' => 'type', 'key' => 'key1', 'value' => 600]);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->orderBy('aggregate')->orderBy('key')->get());
-    expect($aggregates)->toHaveCount(32); // 2 entries * 4 aggregates * 4 periods
+    expect($aggregates)->toHaveCount(40); // 2 entries * 5 aggregates * 4 periods
     expect($aggregates[0])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
     expect($aggregates[1])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
     expect($aggregates[2])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
     expect($aggregates[3])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
     expect($aggregates[4])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
     expect($aggregates[5])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[6])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
-    expect($aggregates[7])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[8])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
-    expect($aggregates[9])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[10])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
-    expect($aggregates[11])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
-    expect($aggregates[12])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
-    expect($aggregates[13])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[14])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
-    expect($aggregates[15])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[16])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
-    expect($aggregates[17])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[18])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
-    expect($aggregates[19])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
-    expect($aggregates[20])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
-    expect($aggregates[21])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[22])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
-    expect($aggregates[23])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[24])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
-    expect($aggregates[25])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[26])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
-    expect($aggregates[27])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
-    expect($aggregates[28])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
-    expect($aggregates[29])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
-    expect($aggregates[30])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
-    expect($aggregates[31])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[6])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[7])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[8])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[9])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+
+    expect($aggregates[10])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[11])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[12])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
+    expect($aggregates[13])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[14])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
+    expect($aggregates[15])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[16])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[17])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[18])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[19])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+
+    expect($aggregates[20])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[21])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[22])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
+    expect($aggregates[23])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[24])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
+    expect($aggregates[25])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[26])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[27])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[28])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[29])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+
+    expect($aggregates[30])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[31])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[32])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
+    expect($aggregates[33])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[34])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
+    expect($aggregates[35])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[36])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'min', 'key' => 'key1', 'value' => 100]);
+    expect($aggregates[37])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'min', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[38])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[39])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
 });
 
 it('combines duplicate count aggregates before upserting', function () {
@@ -117,6 +139,27 @@ it('combines duplicate count aggregates before upserting', function () {
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(3);
     expect($aggregates['key2'])->toEqual(1);
+});
+
+it('combines duplicate min aggregates before upserting', function () {
+    $queries = collect();
+    DB::listen(fn ($query) => $queries[] = $query);
+
+    Pulse::record('type', 'key1', 200)->min();
+    Pulse::record('type', 'key1', 100)->min();
+    Pulse::record('type', 'key1', 300)->min();
+    Pulse::record('type', 'key2', 100)->min();
+    Pulse::store();
+
+    expect($queries)->toHaveCount(2);
+    expect($queries[0]->sql)->toContain('pulse_entries');
+    expect($queries[1]->sql)->toContain('pulse_aggregates');
+    expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
+    expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
+    expect($aggregates['key1'])->toEqual(100);
+    expect($aggregates['key2'])->toEqual(100);
 });
 
 it('combines duplicate max aggregates before upserting', function () {
@@ -194,36 +237,36 @@ it('combines duplicate average aggregates before upserting', function () {
 
 test('one or more aggregates for a single type', function () {
     /*
-    | key      | max | sum  | avg | count |
-    |----------|-----|------|-----|-------|
-    | GET /bar | 600 | 2400 | 400 | 6     |
-    | GET /foo | 300 | 2000 | 200 | 6     |
+    | key      | min | max | sum  | avg | count |
+    |----------|-----|-----|------|-----|-------|
+    | GET /bar | 200 | 600 | 2400 | 400 | 6     |
+    | GET /foo | 100 | 300 | 2000 | 200 | 6     |
     */
 
     // Add entries outside of the window
     Carbon::setTestNow('2000-01-01 12:00:00');
-    Pulse::record('slow_request', 'GET /foo', 100)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 200)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 100)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 200)->min()->max()->sum()->avg()->count();
 
     // Add entries to the "tail"
     Carbon::setTestNow('2000-01-01 12:00:01');
-    Pulse::record('slow_request', 'GET /foo', 100)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 200)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 300)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 400)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 200)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 400)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 600)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 100)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 200)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 300)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 400)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 200)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 400)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 600)->min()->max()->sum()->avg()->count();
 
     // Add entries to the current buckets.
     Carbon::setTestNow('2000-01-01 12:59:00');
-    Pulse::record('slow_request', 'GET /foo', 100)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 200)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 300)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 400)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 200)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 400)->max()->sum()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 600)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 100)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 200)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 300)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 400)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 200)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 400)->min()->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 600)->min()->max()->sum()->avg()->count();
 
     Pulse::store();
 
@@ -236,11 +279,11 @@ test('one or more aggregates for a single type', function () {
         (object) ['key' => 'GET /bar', 'count' => 6],
     ]);
 
-    $results = Pulse::aggregate('slow_request', ['max', 'sum', 'avg', 'count'], CarbonInterval::hour());
+    $results = Pulse::aggregate('slow_request', ['min', 'max', 'sum', 'avg', 'count'], CarbonInterval::hour());
 
     expect($results->all())->toEqual([
-        (object) ['key' => 'GET /bar', 'max' => 600, 'sum' => 2400, 'avg' => 400, 'count' => 6],
-        (object) ['key' => 'GET /foo', 'max' => 400, 'sum' => 2000, 'avg' => 250, 'count' => 8],
+        (object) ['key' => 'GET /bar', 'min' => 200, 'max' => 600, 'sum' => 2400, 'avg' => 400, 'count' => 6],
+        (object) ['key' => 'GET /foo', 'min' => 100, 'max' => 400, 'sum' => 2000, 'avg' => 250, 'count' => 8],
     ]);
 });
 

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -5,6 +5,99 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Laravel\Pulse\Facades\Pulse;
 
+test('aggregation', function () {
+    Pulse::record('type', 'key1', 200)->count()->max()->sum()->avg();
+    Pulse::record('type', 'key1', 100)->count()->max()->sum()->avg();
+    Pulse::record('type', 'key2', 400)->count()->max()->sum()->avg();
+    Pulse::store();
+
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->orderBy('id')->get());
+    expect($entries)->toHaveCount(3);
+    expect($entries[0])->toHaveProperties(['type' => 'type', 'key' => 'key1', 'value' => 200]);
+    expect($entries[1])->toHaveProperties(['type' => 'type', 'key' => 'key1', 'value' => 100]);
+    expect($entries[2])->toHaveProperties(['type' => 'type', 'key' => 'key2', 'value' => 400]);
+
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->orderBy('aggregate')->orderBy('key')->get());
+    expect($aggregates)->toHaveCount(32); // 2 entries * 4 aggregates * 4 periods
+    expect($aggregates[0])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
+    expect($aggregates[1])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[2])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
+    expect($aggregates[3])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[4])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
+    expect($aggregates[5])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[6])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[7])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[8])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
+    expect($aggregates[9])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[10])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
+    expect($aggregates[11])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[12])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
+    expect($aggregates[13])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[14])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[15])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[16])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
+    expect($aggregates[17])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[18])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
+    expect($aggregates[19])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[20])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
+    expect($aggregates[21])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[22])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[23])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[24])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 150]);
+    expect($aggregates[25])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[26])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key1', 'value' => 2]);
+    expect($aggregates[27])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[28])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key1', 'value' => 200]);
+    expect($aggregates[29])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[30])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[31])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+
+    Pulse::record('type', 'key1', 600)->count()->max()->sum()->avg();
+    Pulse::store();
+
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->orderBy('id')->get());
+    expect($entries)->toHaveCount(4);
+    expect($entries[0])->toHaveProperties(['type' => 'type', 'key' => 'key1', 'value' => 200]);
+    expect($entries[1])->toHaveProperties(['type' => 'type', 'key' => 'key1', 'value' => 100]);
+    expect($entries[2])->toHaveProperties(['type' => 'type', 'key' => 'key2', 'value' => 400]);
+    expect($entries[3])->toHaveProperties(['type' => 'type', 'key' => 'key1', 'value' => 600]);
+
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->orderBy('aggregate')->orderBy('key')->get());
+    expect($aggregates)->toHaveCount(32); // 2 entries * 4 aggregates * 4 periods
+    expect($aggregates[0])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[1])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[2])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
+    expect($aggregates[3])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[4])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
+    expect($aggregates[5])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[6])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[7])->toHaveProperties(['type' => 'type', 'period' => 60, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[8])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[9])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[10])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
+    expect($aggregates[11])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[12])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
+    expect($aggregates[13])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[14])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[15])->toHaveProperties(['type' => 'type', 'period' => 360, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[16])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[17])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[18])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
+    expect($aggregates[19])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[20])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
+    expect($aggregates[21])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[22])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[23])->toHaveProperties(['type' => 'type', 'period' => 1440, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[24])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key1', 'value' => 300]);
+    expect($aggregates[25])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'avg', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[26])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key1', 'value' => 3]);
+    expect($aggregates[27])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'count', 'key' => 'key2', 'value' => 1]);
+    expect($aggregates[28])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key1', 'value' => 600]);
+    expect($aggregates[29])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'max', 'key' => 'key2', 'value' => 400]);
+    expect($aggregates[30])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key1', 'value' => 900]);
+    expect($aggregates[31])->toHaveProperties(['type' => 'type', 'period' => 10080, 'aggregate' => 'sum', 'key' => 'key2', 'value' => 400]);
+});
+
 it('combines duplicate count aggregates before upserting', function () {
     $queries = collect();
     DB::listen(fn ($query) => $queries[] = $query);
@@ -47,6 +140,27 @@ it('combines duplicate max aggregates before upserting', function () {
     expect($aggregates['key2'])->toEqual(100);
 });
 
+it('combines duplicate sum aggregates before upserting', function () {
+    $queries = collect();
+    DB::listen(fn ($query) => $queries[] = $query);
+
+    Pulse::record('type', 'key1', 100)->sum();
+    Pulse::record('type', 'key1', 300)->sum();
+    Pulse::record('type', 'key1', 200)->sum();
+    Pulse::record('type', 'key2', 100)->sum();
+    Pulse::store();
+
+    expect($queries)->toHaveCount(2);
+    expect($queries[0]->sql)->toContain('pulse_entries');
+    expect($queries[1]->sql)->toContain('pulse_aggregates');
+    expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
+    expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
+    expect($aggregates['key1'])->toEqual(600);
+    expect($aggregates['key2'])->toEqual(100);
+});
+
 it('combines duplicate average aggregates before upserting', function () {
     $queries = collect();
     DB::listen(fn ($query) => $queries[] = $query);
@@ -80,36 +194,36 @@ it('combines duplicate average aggregates before upserting', function () {
 
 test('one or more aggregates for a single type', function () {
     /*
-    | key      | max | avg | count |
-    |----------|-----|-----|-------|
-    | GET /bar | 600 | 400 | 6     |
-    | GET /foo | 300 | 200 | 6     |
+    | key      | max | sum  | avg | count |
+    |----------|-----|------|-----|-------|
+    | GET /bar | 600 | 2400 | 400 | 6     |
+    | GET /foo | 300 | 2000 | 200 | 6     |
     */
 
     // Add entries outside of the window
     Carbon::setTestNow('2000-01-01 12:00:00');
-    Pulse::record('slow_request', 'GET /foo', 100)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 200)->max()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 100)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 200)->max()->sum()->avg()->count();
 
     // Add entries to the "tail"
     Carbon::setTestNow('2000-01-01 12:00:01');
-    Pulse::record('slow_request', 'GET /foo', 100)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 200)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 300)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 400)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 200)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 400)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 600)->max()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 100)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 200)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 300)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 400)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 200)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 400)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 600)->max()->sum()->avg()->count();
 
     // Add entries to the current buckets.
     Carbon::setTestNow('2000-01-01 12:59:00');
-    Pulse::record('slow_request', 'GET /foo', 100)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 200)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 300)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /foo', 400)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 200)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 400)->max()->avg()->count();
-    Pulse::record('slow_request', 'GET /bar', 600)->max()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 100)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 200)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 300)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /foo', 400)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 200)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 400)->max()->sum()->avg()->count();
+    Pulse::record('slow_request', 'GET /bar', 600)->max()->sum()->avg()->count();
 
     Pulse::store();
 
@@ -122,11 +236,11 @@ test('one or more aggregates for a single type', function () {
         (object) ['key' => 'GET /bar', 'count' => 6],
     ]);
 
-    $results = Pulse::aggregate('slow_request', ['max', 'avg', 'count'], CarbonInterval::hour());
+    $results = Pulse::aggregate('slow_request', ['max', 'sum', 'avg', 'count'], CarbonInterval::hour());
 
     expect($results->all())->toEqual([
-        (object) ['key' => 'GET /bar', 'max' => 600, 'avg' => 400, 'count' => 6],
-        (object) ['key' => 'GET /foo', 'max' => 400, 'avg' => 250, 'count' => 8],
+        (object) ['key' => 'GET /bar', 'max' => 600, 'sum' => 2400, 'avg' => 400, 'count' => 6],
+        (object) ['key' => 'GET /foo', 'max' => 400, 'sum' => 2000, 'avg' => 250, 'count' => 8],
     ]);
 });
 


### PR DESCRIPTION
This PR adds support for "sum" and "min" aggregations, in addition to the "max", "avg", and "count" aggregations we already support.

Also refactored some of the logic to not loop over the entries more than needed, and abstracted the repeated preaggregation logic now that we have five methods.

Cc @aarondfrancis