### PR TITLE
Handle `null` cache keys

### DIFF
--- a/src/Recorders/CacheInteractions.php
+++ b/src/Recorders/CacheInteractions.php
@@ -43,7 +43,7 @@ class CacheInteractions
         [$timestamp, $class, $key] = [
             CarbonImmutable::now()->getTimestamp(),
             $event::class,
-            $event->key,
+            (string) $event->key,
         ];
 
         $this->pulse->lazy(function () use ($timestamp, $class, $key) {


### PR DESCRIPTION
It's _technically_ possible to use a `null` key with `Cache::put` and `Cache::get`. This PR fixes an error in Pulse when this is the case by converting it to an empty string.

Fixes #215 