### PR TITLE
Amend link in upgrade guide

### DIFF
--- a/UPGRADE.MD
+++ b/UPGRADE.MD
@@ -4,7 +4,7 @@
 
 ## Required
 
-- [Added a `highlight` configuration option to `pulse.recorders.SlowQueries` configuration block](https://github.com/laravel/pulse/pull/185).
+- [Added a `highlight` configuration option to `pulse.recorders.SlowQueries` configuration block](https://github.com/laravel/pulse/pull/172).
 
 ## Optional
 


### PR DESCRIPTION
I was checking the upgrade guide to see what will need actioning when 1.x is released and noticed the first link under required pointed to the wrong PR.
