### PR TITLE
[1.x] Fix passing of `Htmlable` class without `__toString` method

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -445,7 +445,7 @@ class Pulse
     public function css(string|Htmlable|array|null $css = null): string|self
     {
         if (func_num_args() === 1) {
-            $this->css = array_values(array_unique(array_merge($this->css, Arr::wrap($css))));
+            $this->css = array_values(array_unique(array_merge($this->css, Arr::wrap($css)), SORT_REGULAR));
 
             return $this;
         }

--- a/tests/Feature/Livewire/CustomCardTest.php
+++ b/tests/Feature/Livewire/CustomCardTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HtmlString;
 use Laravel\Pulse\Facades\Pulse;
 use Laravel\Pulse\Livewire\Card;
@@ -17,6 +18,15 @@ it('loads custom css using a path', function () {
         }
         </style>
         HTML);
+});
+
+it('loads custom css using a HtmlString', function () {
+    Livewire::test(CustomCardWithCssHtmlString::class)
+        ->assertOk();
+
+    $css = Pulse::css();
+
+    expect($css)->toContain('<link rel="stylesheet" src="https://example.com/cdn/custom-card.css">');
 });
 
 it('loads custom css using a Htmlable', function () {
@@ -41,7 +51,7 @@ class CustomCardWithCssPath extends Card
     }
 }
 
-class CustomCardWithCssHtmlable extends Card
+class CustomCardWithCssHtmlString extends Card
 {
     public function render()
     {
@@ -51,5 +61,23 @@ class CustomCardWithCssHtmlable extends Card
     protected function css()
     {
         return new HtmlString('<link rel="stylesheet" src="https://example.com/cdn/custom-card.css">');
+    }
+}
+
+class CustomCardWithCssHtmlable extends Card
+{
+    public function render()
+    {
+        return '<div></div>';
+    }
+
+    protected function css()
+    {
+        return new class implements Htmlable {
+            public function toHtml()
+            {
+                return '<link rel="stylesheet" src="https://example.com/cdn/custom-card.css">';
+            }
+        };
     }
 }

--- a/tests/Feature/Livewire/CustomCardTest.php
+++ b/tests/Feature/Livewire/CustomCardTest.php
@@ -73,7 +73,8 @@ class CustomCardWithCssHtmlable extends Card
 
     protected function css()
     {
-        return new class implements Htmlable {
+        return new class implements Htmlable
+        {
             public function toHtml()
             {
                 return '<link rel="stylesheet" src="https://example.com/cdn/custom-card.css">';


### PR DESCRIPTION
This PR fixes an issue where a `Htmlable` object could not be returned from the `css` method if it did not contain a `__toString` method.