### PR TITLE
[1.x] Ignore telescope for slow queries by default

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -195,6 +195,7 @@ return [
             'location' => env('PULSE_SLOW_QUERIES_LOCATION', true),
             'ignore' => [
                 '/(["`])pulse_[\w]+?\1/', // Pulse tables...
+                '/(["`])telescope_[\w]+?\1/', // Telescope tables...        
             ],
         ],
 

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -205,6 +205,7 @@ return [
             'threshold' => env('PULSE_SLOW_REQUESTS_THRESHOLD', 1000),
             'ignore' => [
                 '#^/pulse$#', // Pulse dashboard...
+                '#^/telescope#', // Telescope dashboard...
             ],
         ],
 
@@ -221,6 +222,7 @@ return [
             'sample_rate' => env('PULSE_USER_REQUESTS_SAMPLE_RATE', 1),
             'ignore' => [
                 '#^/pulse$#', // Pulse dashboard...
+                '#^/telescope#', // Telescope dashboard...
             ],
         ],
     ],


### PR DESCRIPTION
While in local development with a low threshold. I ended up with lots of telescope entries in the slow queries table. This made the dashboard very slow with over 1000 slow queries.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
