### PR TITLE
[1.x] Use `PULSE_PATH` env instead of fixed text for `/pulse`

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -204,7 +204,7 @@ return [
             'sample_rate' => env('PULSE_SLOW_REQUESTS_SAMPLE_RATE', 1),
             'threshold' => env('PULSE_SLOW_REQUESTS_THRESHOLD', 1000),
             'ignore' => [
-                '#^/' . env('PULSE_PATH', 'pulse') . '$#', // Pulse dashboard...
+                '#^/'.env('PULSE_PATH', 'pulse').'$#', // Pulse dashboard...
             ],
         ],
 

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -204,7 +204,7 @@ return [
             'sample_rate' => env('PULSE_SLOW_REQUESTS_SAMPLE_RATE', 1),
             'threshold' => env('PULSE_SLOW_REQUESTS_THRESHOLD', 1000),
             'ignore' => [
-                '#^/pulse$#', // Pulse dashboard...
+                '#^/' . env('PULSE_PATH', 'pulse') . '$#', // Pulse dashboard...
             ],
         ],
 
@@ -220,7 +220,7 @@ return [
             'enabled' => env('PULSE_USER_REQUESTS_ENABLED', true),
             'sample_rate' => env('PULSE_USER_REQUESTS_SAMPLE_RATE', 1),
             'ignore' => [
-                '#^/pulse$#', // Pulse dashboard...
+                '#^/' . env('PULSE_PATH', 'pulse') . '$#', // Pulse dashboard...
             ],
         ],
     ],

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -220,7 +220,7 @@ return [
             'enabled' => env('PULSE_USER_REQUESTS_ENABLED', true),
             'sample_rate' => env('PULSE_USER_REQUESTS_SAMPLE_RATE', 1),
             'ignore' => [
-                '#^/' . env('PULSE_PATH', 'pulse') . '$#', // Pulse dashboard...
+                '#^/'.env('PULSE_PATH', 'pulse').'$#', // Pulse dashboard...
             ],
         ],
     ],


### PR DESCRIPTION
In the configuration file, we statically refer to the `/pulse` path during restrictions. However, **the path should be dynamically determined from the `PULSE_PATH` environment variable**.