### PR TITLE
Renamed purge to clear

### DIFF
--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -31,6 +31,13 @@ class ClearCommand extends Command
     public $description = 'Delete all Pulse data from storage';
 
     /**
+     * The console command name aliases.
+     *
+     * @var array
+     */
+    protected $aliases = ['pulse:purge'];
+
+    /**
      * Handle the command.
      */
     public function handle(Storage $storage): int

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -28,7 +28,7 @@ class ClearCommand extends Command
      *
      * @var string
      */
-    public $description = 'Clear Pulse data';
+    public $description = 'Delete all Pulse data from storage';
 
     /**
      * Handle the command.

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
  * @internal
  */
 #[AsCommand(name: 'pulse:clear')]
-class PurgeCommand extends Command
+class ClearCommand extends Command
 {
     use ConfirmableTrait;
 

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 /**
  * @internal
  */
-#[AsCommand(name: 'pulse:purge')]
+#[AsCommand(name: 'pulse:clear')]
 class PurgeCommand extends Command
 {
     use ConfirmableTrait;
@@ -20,7 +20,7 @@ class PurgeCommand extends Command
      *
      * @var string
      */
-    public $signature = 'pulse:purge {--type=* : Only clear the specified type(s)}
+    public $signature = 'pulse:clear {--type=* : Only clear the specified type(s)}
                                      {--force : Force the operation to run when in production}';
 
     /**
@@ -28,7 +28,7 @@ class PurgeCommand extends Command
      *
      * @var string
      */
-    public $description = 'Purge Pulse data';
+    public $description = 'Clear Pulse data';
 
     /**
      * Handle the command.

--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -214,7 +214,7 @@ class PulseServiceProvider extends ServiceProvider
                 Commands\WorkCommand::class,
                 Commands\CheckCommand::class,
                 Commands\RestartCommand::class,
-                Commands\PurgeCommand::class,
+                Commands\ClearCommand::class,
             ]);
         }
     }

--- a/tests/Feature/Commands/ClearCommandTest.php
+++ b/tests/Feature/Commands/ClearCommandTest.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Laravel\Pulse\Facades\Pulse;
 
-it('purges Pulse data', function () {
+it('clears Pulse data', function () {
     Pulse::set('foo', 'bar', 'baz');
     Pulse::record('foo', 'bar', 123)->max()->count();
     Pulse::store();
@@ -13,7 +13,7 @@ it('purges Pulse data', function () {
     expect(DB::table('pulse_entries')->count())->toBe(1);
     expect(DB::table('pulse_aggregates')->count())->toBe(8);
 
-    Artisan::call('pulse:purge');
+    Artisan::call('pulse:clear');
 
     expect(DB::table('pulse_values')->count())->toBe(0);
     expect(DB::table('pulse_entries')->count())->toBe(0);
@@ -31,7 +31,7 @@ it('can specify types', function () {
     expect(DB::table('pulse_entries')->count())->toBe(2);
     expect(DB::table('pulse_aggregates')->count())->toBe(16);
 
-    Artisan::call('pulse:purge --type delete-me');
+    Artisan::call('pulse:clear --type delete-me');
 
     expect(DB::table('pulse_values')->where('type', 'keep-me')->count())->toBe(1);
     expect(DB::table('pulse_values')->where('type', 'delete-me')->count())->toBe(0);


### PR DESCRIPTION
# Changes Made:
Renamed PurgeCommand to ClearCommand to align with the naming convention used in the Telescope package.

# Context:
This pull request addresses the need for consistency in command naming across packages. The existing command, PurgeCommand, has been renamed to ClearCommand to harmonize with the conventions established in the Telescope package.

# Justification:
Maintaining a consistent naming scheme is crucial for code readability and collaboration. Aligning the command names with those in the Telescope package not only improves uniformity within across the codebases but also enhances the overall developer experience.