### PR TITLE
[1.x] Transforming ignored paths into valid paths

### DIFF
--- a/src/Recorders/Concerns/Ignores.php
+++ b/src/Recorders/Concerns/Ignores.php
@@ -11,6 +11,6 @@ trait Ignores
     {
         // @phpstan-ignore argument.templateType, argument.templateType
         return collect($this->config->get('pulse.recorders.'.static::class.'.ignore'))
-            ->contains(fn (string $pattern) => preg_match(preg_replace(['#/{2,}#', '#/\$\##'], ['/', '$#'], $pattern), $value));
+            ->contains(fn (string $pattern) => preg_match(preg_replace(['#/{2,}#', '#/\$\##'], ['/', '$#'], $pattern) ?? $pattern, $value));
     }
 }

--- a/src/Recorders/Concerns/Ignores.php
+++ b/src/Recorders/Concerns/Ignores.php
@@ -11,6 +11,6 @@ trait Ignores
     {
         // @phpstan-ignore argument.templateType, argument.templateType
         return collect($this->config->get('pulse.recorders.'.static::class.'.ignore'))
-            ->contains(fn (string $pattern) => preg_match(preg_replace(['#/{2,}#', '#/\$\##'], ['/', '$#'], $pattern) ?? $pattern, $value));
+            ->contains(fn (string $pattern) => preg_match(preg_replace(['#(?<!:)/{2,}#', '#/\$\##'], ['/', '$#'], $pattern) ?? $pattern, $value));
     }
 }

--- a/src/Recorders/Concerns/Ignores.php
+++ b/src/Recorders/Concerns/Ignores.php
@@ -11,6 +11,6 @@ trait Ignores
     {
         // @phpstan-ignore argument.templateType, argument.templateType
         return collect($this->config->get('pulse.recorders.'.static::class.'.ignore'))
-            ->contains(fn (string $pattern) => preg_match($pattern, $value));
+            ->contains(fn (string $pattern) => preg_match(preg_replace(['#/{2,}#', '#/\$\##'], ['/', '$#'], $pattern), $value));
     }
 }


### PR DESCRIPTION
Today, I reused the `PULSE_PATH` variable in the `ignore` paths (see https://github.com/laravel/pulse/pull/229).

Several issues have arisen, which the Router typically handles for the path, so, in general, they do not occur (see https://github.com/laravel/pulse/pull/229#discussion_r1426590745). However, I used the same `PULSE_PATH` variable in the `ignore`. The problem here can be caused by various ways of representing the path:

- It can start with or without a leading `/` (in both cases, we are referring to the same thing).
    - example.1 - `developer/pulse`
    - example.2 - `developer/pulse/`
- It can end with or without a trailing `/` (if specifically referring to this URL, i.e., if the regex ends with `$`, then in both cases, we are talking about the same thing).
    - example.1 - `developer/pulse`
    - example.2 - `/developer/pulse`
- It may contain accidental `//` duplications (which need to be replaced with a single `/`). 
    - example.1 - `'/'.env('PULSE_PATH')`, where `PULSE_PATH` is `developer/pulse`, result: `/developer/pulse`
    - example.2 - `'/'.env('PULSE_PATH')`, where `PULSE_PATH` is `/developer/pulse`, result: `//developer/pulse`

We need to perform 2 transformations for this.
- One is removing the duplications (`//` to `/`)
    - `preg_replace('#/{2,}#', '/', $pattern)`
    - and due to external `ignore`, retain the `://` with `(?<!:)` condition --> `preg_replace('#(?<!:)/{2,}#', '/', $pattern)`
- and if the regex ends with `$#`, then in that case, replace `/$#` with `$#`. (`/$#` to `$#`)
    - `preg_replace('#/\$\##', '$#', $pattern)`
    
In summary,

```diff
protected function shouldIgnore(string $value): bool
{
    // @phpstan-ignore argument.templateType, argument.templateType
    return collect($this->config->get('pulse.recorders.'.static::class.'.ignore'))
-        ->contains(fn (string $pattern) => preg_match($pattern, $value));
+        ->contains(fn (string $pattern) => preg_match(preg_replace(['#(?<!:)/{2,}#', '#/\$\##'], ['/', '$#'], $pattern) ?? $pattern, $value));
 }
```