### PR TITLE
[1.x] Add scrollbar styling

### DIFF
--- a/resources/views/components/scroll.blade.php
+++ b/resources/views/components/scroll.blade.php
@@ -22,7 +22,7 @@
     }"
     {{ $attributes->merge(['class' => '@container/scroll-wrapper flex-grow flex w-full overflow-hidden' . ($expand ? '' : ' basis-56'), ':class' => "loading && 'opacity-25 animate-pulse'"]) }}
 >
-    <div x-ref="content" class="flex-grow basis-full overflow-y-auto" @scroll.debounce.5ms="scroll">
+    <div x-ref="content" class="flex-grow basis-full overflow-y-auto scrollbar:w-1.5 scrollbar:h-1.5 scrollbar:bg-transparent scrollbar-track:bg-gray-100 scrollbar-thumb:rounded scrollbar-thumb:bg-gray-300 scrollbar-track:rounded dark:scrollbar-track:bg-gray-500/10 dark:scrollbar-thumb:bg-gray-500/50 supports-scrollbars:pr-3" @scroll.debounce.5ms="scroll">
         {{ $slot }}
         <div x-ref="fade" class="h-6 origin-bottom fixed bottom-0 left-0 right-0 bg-gradient-to-t from-white dark:from-gray-900 pointer-events-none" wire:ignore></div>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,6 +33,10 @@ module.exports = {
         require("@tailwindcss/container-queries"),
         function ({ addVariant }) {
             addVariant('default', 'html :where(&)')
-        }
+            addVariant('supports-scrollbars', '@supports selector(::-webkit-scrollbar)'),
+            addVariant('scrollbar', '&::-webkit-scrollbar')
+            addVariant('scrollbar-track', '&::-webkit-scrollbar-track')
+            addVariant('scrollbar-thumb', '&::-webkit-scrollbar-thumb')
+        },
     ],
 };


### PR DESCRIPTION
This adds the capability for the `scroll.blade.php` component to have styled scrollbars.

## Before

### Light Mode
<img width="669" alt="image" src="https://github.com/laravel/pulse/assets/823088/06cc3f87-16e4-419e-a117-4ba40d663f41">

### Dark Mode
<img width="662" alt="image" src="https://github.com/laravel/pulse/assets/823088/04bb7efa-1d6a-437e-b797-cce5c71af183">


## After

### Light Mode
<img width="661" alt="image" src="https://github.com/laravel/pulse/assets/823088/843ca1f8-7679-466b-8a6c-4cab68d9ebcf">

### Dark Mode
<img width="701" alt="image" src="https://github.com/laravel/pulse/assets/823088/c67fb66f-306c-4384-8eda-5b9754840059">

## Note:

The technique used was the same used on [tailwindcss.com](https://tailwindcss.com) website.