### PR TITLE
[1.x] Improve migration errors to guide developers with unsupported drivers

### DIFF
--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -33,14 +33,14 @@ class PulseMigration extends Migration
         }
 
         if (Config::get('pulse.enabled')) {
-            throw new RuntimeException("Pulse does not support the [{$this->driver()}] database driver. You can disable Pulse in your testsuite by setting `<env name=\"PULSE_ENABLED\" value=\"false\"/>` in your project's `phpunit.xml` file.");
+            throw new RuntimeException("Pulse does not support the [{$this->driver()}] database driver. You can disable Pulse in your testsuite by adding `<env name=\"PULSE_ENABLED\" value=\"false\"/>` to your project's `phpunit.xml` file.");
         }
 
         return false;
     }
 
     /**
-     * The database connection driver.
+     * Get the database connection driver.
      */
     protected function driver(): string
     {

--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -28,7 +28,7 @@ class PulseMigration extends Migration
             return true;
         }
 
-        if (! App::environment('testing') ) {
+        if (! App::environment('testing')) {
             throw new RuntimeException("Pulse does not support the [{$this->driver()}] database driver.");
         }
 

--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\Pulse\Support;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class PulseMigration extends Migration
+{
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return Config::get('pulse.storage.database.connection');
+    }
+
+    /**
+     * Determine if the migration should run.
+     */
+    protected function shouldRun(): bool
+    {
+        if (in_array($this->driver(), ['mysql', 'pgsql'])) {
+            return true;
+        }
+
+        if (! App::environment('testing') ) {
+            throw new RuntimeException("Pulse does not support the [{$this->driver()}] database driver.");
+        }
+
+        if (Config::get('pulse.enabled')) {
+            throw new RuntimeException("Pulse does not support the [{$this->driver()}] database driver. You can disable Pulse in your testsuite by setting `<env name=\"PULSE_ENABLED\" value=\"false\"/>` in your project's `phpunit.xml` file.");
+        }
+
+        return true;
+    }
+
+    /**
+     * The database connection driver.
+     */
+    protected function driver(): string
+    {
+        return DB::connection($this->getConnection())->getDriverName();
+    }
+}

--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -36,7 +36,7 @@ class PulseMigration extends Migration
             throw new RuntimeException("Pulse does not support the [{$this->driver()}] database driver. You can disable Pulse in your testsuite by setting `<env name=\"PULSE_ENABLED\" value=\"false\"/>` in your project's `phpunit.xml` file.");
         }
 
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
### `phpunit` + `sqlite` + `PULSE_ENABLED=false`

Database migrations are ignored ✅

<img width="765" alt="Screenshot 2023-12-15 at 9 59 04 am" src="https://github.com/laravel/pulse/assets/24803032/d055309c-8c34-4e8d-9325-2d29b2f94b22">

---

### `phpunit` + `sqlite` + `PULSE_ENABLED=true`

Throws an exception pointing developer to disable pulse if they want to.

<img width="1918" alt="Screenshot 2023-12-15 at 9 50 29 am" src="https://github.com/laravel/pulse/assets/24803032/08d2b41b-aed4-4cbc-9a49-52bcbd424520">

---

### `artisan migrate` + `sqlite` + `PULSE_ENABLED=true`

Throws an exception indicating that the DB is not supported.

<img width="1381" alt="Screenshot 2023-12-15 at 9 57 52 am" src="https://github.com/laravel/pulse/assets/24803032/63a04ba1-bc11-44a6-8e84-88ef8030bc2d">

---

### `artisan migration` + `sqlite` + `PULSE_ENABLED=false`

Throws an exception indicating that the DB is not supported. This is important because we don't want to record in the migrations table that the migration has been run, because enabling pulse later will not work.

<img width="1385" alt="Screenshot 2023-12-15 at 9 58 27 am" src="https://github.com/laravel/pulse/assets/24803032/8a5369f3-ea2c-46a5-a2f1-48434e983012">