### PR TITLE
[1.x] Ignore all internal pulse activity

### DIFF
--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -72,7 +72,7 @@ class CheckCommand extends Command
                 $event->dispatch(new IsolatedBeat($lastSnapshotAt, $interval));
             }
 
-            $pulse->store();
+            $pulse->ingest();
         }
     }
 }

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -4,7 +4,7 @@ namespace Laravel\Pulse\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Laravel\Pulse\Contracts\Storage;
+use Laravel\Pulse\Pulse;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
@@ -40,7 +40,7 @@ class ClearCommand extends Command
     /**
      * Handle the command.
      */
-    public function handle(Storage $storage): int
+    public function handle(Pulse $pulse): int
     {
         if (! $this->confirmToProceed()) {
             return Command::FAILURE;
@@ -49,12 +49,12 @@ class ClearCommand extends Command
         if (is_array($this->option('type')) && count($this->option('type')) > 0) {
             $this->components->task(
                 'Purging Pulse data for ['.implode(', ', $this->option('type')).']',
-                fn () => $storage->purge($this->option('type'))
+                fn () => $pulse->purge($this->option('type'))
             );
         } else {
             $this->components->task(
                 'Purging all Pulse data',
-                fn () => $storage->purge()
+                fn () => $pulse->purge(),
             );
         }
 

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -5,8 +5,7 @@ namespace Laravel\Pulse\Commands;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
 use Illuminate\Support\Sleep;
-use Laravel\Pulse\Contracts\Ingest;
-use Laravel\Pulse\Contracts\Storage;
+use Laravel\Pulse\Pulse;
 use Laravel\Pulse\Support\CacheStoreResolver;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -34,8 +33,7 @@ class WorkCommand extends Command
      * Handle the command.
      */
     public function handle(
-        Ingest $ingest,
-        Storage $storage,
+        Pulse $pulse,
         CacheStoreResolver $cache,
     ): int {
         $lastRestart = $cache->store()->get('laravel:pulse:restart');
@@ -49,10 +47,10 @@ class WorkCommand extends Command
                 return self::SUCCESS;
             }
 
-            $ingest->store($storage);
+            $pulse->digest();
 
             if ($now->subMinutes(10)->greaterThan($lastTrimmedStorageAt)) {
-                $storage->trim();
+                $pulse->trim();
 
                 $lastTrimmedStorageAt = $now;
             }

--- a/src/Contracts/Ingest.php
+++ b/src/Contracts/Ingest.php
@@ -14,12 +14,12 @@ interface Ingest
     public function ingest(Collection $items): void;
 
     /**
+     * Digest the ingested items.
+     */
+    public function digest(Storage $storage): int;
+
+    /**
      * Trim the ingest.
      */
     public function trim(): void;
-
-    /**
-     * Store the ingested items.
-     */
-    public function store(Storage $storage): int;
 }

--- a/src/Facades/Pulse.php
+++ b/src/Facades/Pulse.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Laravel\Pulse\Pulse flush()
  * @method static \Laravel\Pulse\Pulse filter(callable $filter)
  * @method static int ingest()
+ * @method static int digest()
  * @method static \Illuminate\Support\Collection recorders()
  * @method static \Illuminate\Support\Collection resolveUsers(\Illuminate\Support\Collection $ids)
  * @method static \Laravel\Pulse\Pulse users(callable $callback)

--- a/src/Facades/Pulse.php
+++ b/src/Facades/Pulse.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static mixed ignore(callable $callback)
  * @method static \Laravel\Pulse\Pulse flush()
  * @method static \Laravel\Pulse\Pulse filter(callable $filter)
- * @method static int store()
+ * @method static int ingest()
  * @method static \Illuminate\Support\Collection recorders()
  * @method static \Illuminate\Support\Collection resolveUsers(\Illuminate\Support\Collection $ids)
  * @method static \Laravel\Pulse\Pulse users(callable $callback)

--- a/src/Ingests/RedisIngest.php
+++ b/src/Ingests/RedisIngest.php
@@ -71,9 +71,9 @@ class RedisIngest implements Ingest
     }
 
     /**
-     * Store the ingested items.
+     * Digest the ingested items.
      */
-    public function store(Storage $storage): int
+    public function digest(Storage $storage): int
     {
         $total = 0;
 

--- a/src/Ingests/StorageIngest.php
+++ b/src/Ingests/StorageIngest.php
@@ -38,9 +38,9 @@ class StorageIngest implements Ingest
     }
 
     /**
-     * Store the ingested items.
+     * Digest the ingested items.
      */
-    public function store(Storage $storage): int
+    public function digest(Storage $storage): int
     {
         return 0;
     }

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -597,8 +597,6 @@ class Pulse
      */
     public function __call($method, $parameters): mixed
     {
-        $storage = $this->app->make(Storage::class);
-
-        return $this->ignore(fn () => $this->forwardCallTo($storage, $method, $parameters));
+        return $this->ignore(fn () => $this->forwardCallTo($this->app->make(Storage::class), $method, $parameters));
     }
 }

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -293,6 +293,7 @@ class Pulse
         $entries = $this->rescue(function () {
             $this->lazy->each(fn ($lazy) => $lazy());
 
+            // here as well.
             return $this->entries->filter($this->shouldRecord(...));
         }) ?? collect([]);
 
@@ -328,7 +329,7 @@ class Pulse
     public function digest(): int
     {
         return $this->ignore(
-            fn () => $this->app->make(Ingest::class)->store($this->app->make(Storage::class))
+            fn () => $this->app->make(Ingest::class)->digest($this->app->make(Storage::class))
         );
     }
 

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -293,8 +293,7 @@ class Pulse
         $entries = $this->rescue(function () {
             $this->lazy->each(fn ($lazy) => $lazy());
 
-            // here as well.
-            return $this->entries->filter($this->shouldRecord(...));
+            return $this->ignore(fn () => $this->entries->filter($this->shouldRecord(...)));
         }) ?? collect([]);
 
         if ($entries->isEmpty()) {

--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -123,19 +123,19 @@ class PulseServiceProvider extends ServiceProvider
                     Looping::class,
                     WorkerStopping::class,
                 ], function () use ($app) {
-                    $app->make(Pulse::class)->store();
+                    $app->make(Pulse::class)->ingest();
                 });
             });
 
             $this->callAfterResolving(HttpKernel::class, function (HttpKernel $kernel, Application $app) {
                 $kernel->whenRequestLifecycleIsLongerThan(-1, function () use ($app) { // @phpstan-ignore method.notFound
-                    $app->make(Pulse::class)->store();
+                    $app->make(Pulse::class)->ingest();
                 });
             });
 
             $this->callAfterResolving(ConsoleKernel::class, function (ConsoleKernel $kernel, Application $app) {
                 $kernel->whenCommandLifecycleIsLongerThan(-1, function () use ($app) { // @phpstan-ignore method.notFound
-                    $app->make(Pulse::class)->store();
+                    $app->make(Pulse::class)->ingest();
                 });
             });
         });

--- a/tests/Feature/Commands/ClearCommandTest.php
+++ b/tests/Feature/Commands/ClearCommandTest.php
@@ -7,17 +7,21 @@ use Laravel\Pulse\Facades\Pulse;
 it('clears Pulse data', function () {
     Pulse::set('foo', 'bar', 'baz');
     Pulse::record('foo', 'bar', 123)->max()->count();
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(DB::table('pulse_values')->count())->toBe(1);
-    expect(DB::table('pulse_entries')->count())->toBe(1);
-    expect(DB::table('pulse_aggregates')->count())->toBe(8);
+    Pulse::ignore(function () {
+        expect(DB::table('pulse_values')->count())->toBe(1);
+        expect(DB::table('pulse_entries')->count())->toBe(1);
+        expect(DB::table('pulse_aggregates')->count())->toBe(8);
+    });
 
     Artisan::call('pulse:clear');
 
-    expect(DB::table('pulse_values')->count())->toBe(0);
-    expect(DB::table('pulse_entries')->count())->toBe(0);
-    expect(DB::table('pulse_aggregates')->count())->toBe(0);
+    Pulse::ignore(function () {
+        expect(DB::table('pulse_values')->count())->toBe(0);
+        expect(DB::table('pulse_entries')->count())->toBe(0);
+        expect(DB::table('pulse_aggregates')->count())->toBe(0);
+    });
 });
 
 it('can specify types', function () {
@@ -25,18 +29,22 @@ it('can specify types', function () {
     Pulse::set('delete-me', 'foo', 'bar');
     Pulse::record('keep-me', 'foo', 123)->max()->count();
     Pulse::record('delete-me', 'foo', 123)->max()->count();
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(DB::table('pulse_values')->count())->toBe(2);
-    expect(DB::table('pulse_entries')->count())->toBe(2);
-    expect(DB::table('pulse_aggregates')->count())->toBe(16);
+    Pulse::ignore(function () {
+        expect(DB::table('pulse_values')->count())->toBe(2);
+        expect(DB::table('pulse_entries')->count())->toBe(2);
+        expect(DB::table('pulse_aggregates')->count())->toBe(16);
+    });
 
     Artisan::call('pulse:clear --type delete-me');
 
-    expect(DB::table('pulse_values')->where('type', 'keep-me')->count())->toBe(1);
-    expect(DB::table('pulse_values')->where('type', 'delete-me')->count())->toBe(0);
-    expect(DB::table('pulse_entries')->where('type', 'keep-me')->count())->toBe(1);
-    expect(DB::table('pulse_entries')->where('type', 'delete-me')->count())->toBe(0);
-    expect(DB::table('pulse_aggregates')->where('type', 'keep-me')->count())->toBe(8);
-    expect(DB::table('pulse_aggregates')->where('type', 'delete-me')->count())->toBe(0);
+    Pulse::ignore(function () {
+        expect(DB::table('pulse_values')->where('type', 'keep-me')->count())->toBe(1);
+        expect(DB::table('pulse_values')->where('type', 'delete-me')->count())->toBe(0);
+        expect(DB::table('pulse_entries')->where('type', 'keep-me')->count())->toBe(1);
+        expect(DB::table('pulse_entries')->where('type', 'delete-me')->count())->toBe(0);
+        expect(DB::table('pulse_aggregates')->where('type', 'keep-me')->count())->toBe(8);
+        expect(DB::table('pulse_aggregates')->where('type', 'delete-me')->count())->toBe(0);
+    });
 });

--- a/tests/Feature/Ingests/DatabaseTest.php
+++ b/tests/Feature/Ingests/DatabaseTest.php
@@ -4,9 +4,11 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Laravel\Pulse\Facades\Pulse;
 use Laravel\Pulse\Storage\DatabaseStorage;
 
 it('trims values at or past expiry', function () {
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-08 00:00:05');
     DB::table('pulse_values')->insert([
         ['type' => 'type', 'key' => 'foo', 'value' => 'value', 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:04')->getTimestamp()],
@@ -20,6 +22,7 @@ it('trims values at or past expiry', function () {
 });
 
 it('trims entries at or after week after timestamp', function () {
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-08 00:00:05');
     DB::table('pulse_entries')->insert([
         ['type' => 'foo', 'key' => 'xxxx', 'value' => 1, 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:04')->getTimestamp()],
@@ -33,6 +36,7 @@ it('trims entries at or after week after timestamp', function () {
 });
 
 it('trims aggregates once the bucket is no longer relevant', function () {
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-08 01:01:05');
 
     DB::table('pulse_aggregates')->insert([

--- a/tests/Feature/Livewire/CacheTest.php
+++ b/tests/Feature/Livewire/CacheTest.php
@@ -37,7 +37,7 @@ it('renders cache statistics', function () {
     Pulse::record('cache_miss', 'foo')->count();
     Pulse::record('cache_miss', 'bar')->count();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(Cache::class, ['lazy' => false])
         ->assertViewHas('allCacheInteractions', (object) [
@@ -55,7 +55,7 @@ it('does not round numbers up', function () {
         Pulse::record('cache_hit', 'foo')->count()->onlyBuckets();
     }
     Pulse::record('cache_miss', 'foo')->count()->onlyBuckets();
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(Cache::class, ['lazy' => false])
         ->assertDontSeeHtml("100.00%\n")
@@ -65,7 +65,7 @@ it('does not round numbers up', function () {
 it('does not show decimals for round numbers', function () {
     Pulse::record('cache_hit', 'foo')->count()->onlyBuckets();
     Pulse::record('cache_miss', 'foo')->count()->onlyBuckets();
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(Cache::class, ['lazy' => false])
         ->assertDontSeeHtml("50.00%\n")

--- a/tests/Feature/Livewire/ExceptionsTest.php
+++ b/tests/Feature/Livewire/ExceptionsTest.php
@@ -32,7 +32,7 @@ it('renders exceptions', function () {
     Pulse::record('exception', $exception1, now()->timestamp)->max()->count();
     Pulse::record('exception', $exception2, now()->timestamp)->max()->count();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(Exceptions::class, ['lazy' => false])
         ->assertViewHas('exceptions', collect([

--- a/tests/Feature/Livewire/QueuesTest.php
+++ b/tests/Feature/Livewire/QueuesTest.php
@@ -33,7 +33,7 @@ it('renders queue statistics', function () {
     Pulse::record('processed', 'database:default')->count()->onlyBuckets();
     Pulse::record('released', 'database:default')->count()->onlyBuckets();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(Queues::class, ['lazy' => false])
         ->assertViewHas('queues', collect([

--- a/tests/Feature/Livewire/ServersTest.php
+++ b/tests/Feature/Livewire/ServersTest.php
@@ -36,7 +36,7 @@ it('renders server statistics', function () {
         ],
     ]));
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(Servers::class, ['lazy' => false])
         ->assertViewHas('servers', collect([

--- a/tests/Feature/Livewire/SlowJobsTest.php
+++ b/tests/Feature/Livewire/SlowJobsTest.php
@@ -29,7 +29,7 @@ it('renders slow jobs', function () {
     Pulse::record('slow_job', 'App\Jobs\MyJob', 1000)->max()->count();
     Pulse::record('slow_job', 'App\Jobs\MyOtherJob', 1000)->max()->count();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(SlowJobs::class, ['lazy' => false])
         ->assertViewHas('slowJobs', collect([

--- a/tests/Feature/Livewire/SlowOutgoingRequestsTest.php
+++ b/tests/Feature/Livewire/SlowOutgoingRequestsTest.php
@@ -29,7 +29,7 @@ it('renders slow outgoing requests', function () {
     Pulse::record('slow_outgoing_request', json_encode(['GET', 'http://example.com']), 1000)->max()->count();
     Pulse::record('slow_outgoing_request', json_encode(['GET', 'http://example.org']), 1000)->max()->count();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(SlowOutgoingRequests::class, ['lazy' => false])
         ->assertViewHas('slowOutgoingRequests', collect([

--- a/tests/Feature/Livewire/SlowQueriesTest.php
+++ b/tests/Feature/Livewire/SlowQueriesTest.php
@@ -32,7 +32,7 @@ it('renders slow queries', function () {
     Pulse::record('slow_query', $query1, 1000)->max()->count();
     Pulse::record('slow_query', $query2, 1000)->max()->count();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(SlowQueries::class, ['lazy' => false])
         ->assertViewHas('slowQueries', collect([

--- a/tests/Feature/Livewire/SlowRequestsTest.php
+++ b/tests/Feature/Livewire/SlowRequestsTest.php
@@ -32,7 +32,7 @@ it('renders slow requests', function () {
     Pulse::record('slow_request', $request1, 1000)->max()->count();
     Pulse::record('slow_request', $request2, 1000)->max()->count();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::test(SlowRequests::class, ['lazy' => false])
         ->assertViewHas('slowRequests', collect([

--- a/tests/Feature/Livewire/UsageTest.php
+++ b/tests/Feature/Livewire/UsageTest.php
@@ -42,7 +42,7 @@ it('renders top 10 users making requests', function (string $query, string $type
     Pulse::record($type, $users[1]->id)->count();
     Pulse::record($type, $users[2]->id)->count();
 
-    Pulse::store();
+    Pulse::ingest();
 
     Livewire::withQueryParams(['usage' => $query])
         ->test(Usage::class, ['lazy' => false])

--- a/tests/Feature/PulseTest.php
+++ b/tests/Feature/PulseTest.php
@@ -17,7 +17,7 @@ it('can filter records', function () {
     Pulse::record('foo', 'keep', 0);
     Pulse::set('baz', 'keep', '');
     Pulse::set('baz', 'ignore', '');
-    Pulse::store();
+    Pulse::ingest();
 
     expect($storage->stored)->toHaveCount(2);
     expect($storage->stored[0])->toBeInstanceOf(Entry::class);
@@ -35,7 +35,7 @@ it('can lazily capture entries', function () {
         Pulse::set('value', 'lazy', '1');
     });
     Pulse::set('value', 'eager', '1');
-    Pulse::store();
+    Pulse::ingest();
 
     expect($storage->stored)->toHaveCount(4);
     expect($storage->stored[0])->toBeInstanceOf(Entry::class);
@@ -57,5 +57,5 @@ it('can flush the queue', function () {
     });
     Pulse::flush();
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });

--- a/tests/Feature/Recorders/CacheInteractionsTest.php
+++ b/tests/Feature/Recorders/CacheInteractionsTest.php
@@ -14,7 +14,7 @@ it('ingests cache interactions', function () {
     Cache::put('hit-key', 1);
     Cache::get('hit-key');
     Cache::get('miss-key');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(2);
@@ -53,20 +53,20 @@ it('ingests cache interactions', function () {
 it('ignores internal illuminate cache interactions', function () {
     Cache::get('illuminate:');
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('ignores internal pulse cache interactions', function () {
     Cache::get('laravel:pulse:');
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('stores the original keys by default', function () {
     Carbon::setTestNow('2000-01-02 03:04:05');
 
     Cache::get('users:1234:profile');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -85,7 +85,7 @@ it('can normalize cache keys', function () {
         '/users:\d+:profile/' => 'users:{user}:profile',
     ]);
     Cache::get('users:1234:profile');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -104,7 +104,7 @@ it('can use back references in normalized cache keys', function () {
         '/^([^:]+):([^:]+):baz/' => '\2:\1',
     ]);
     Cache::get('foo:bar:baz');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -123,7 +123,7 @@ it('uses the original key if no matching pattern is found', function () {
         '/\d/' => 'foo',
     ]);
     Cache::get('actual-key');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -143,7 +143,7 @@ it('can provide regex flags in normalization key', function () {
         '/FOO/i' => 'uppercase-key',
     ]);
     Cache::get('FOO');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -162,7 +162,7 @@ it('can ignore keys', function () {
 
     Cache::get('laravel:pulse:foo:bar');
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample', function () {
@@ -179,13 +179,13 @@ it('can sample', function () {
     Cache::get('foo');
     Cache::get('foo');
 
-    expect(Pulse::store())->toEqualWithDelta(1, 4);
+    expect(Pulse::ingest())->toEqualWithDelta(1, 4);
 });
 
 it('groups job exception keys', function () {
     Cache::get('job-exceptions:'.Str::uuid());
 
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);

--- a/tests/Feature/Recorders/ExceptionsTest.php
+++ b/tests/Feature/Recorders/ExceptionsTest.php
@@ -11,7 +11,7 @@ it('ingests exceptions', function () {
 
     report(new RuntimeException('Expected exception.'));
 
-    expect(Pulse::store())->toBe(1);
+    expect(Pulse::ingest())->toBe(1);
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -51,7 +51,7 @@ it('can disable capturing the location', function () {
     Carbon::setTestNow('2000-01-02 03:04:05');
 
     report(new RuntimeException('Expected exception.'));
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -88,7 +88,7 @@ it('can manually report exceptions', function () {
     Carbon::setTestNow('2000-01-01 00:00:00');
 
     Pulse::report(new MyReportedException('Hello, Pulse!'));
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -109,7 +109,7 @@ it('can ignore exceptions', function () {
 
     report(new \Tests\Feature\Exceptions\MyException('Ignored exception'));
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample', function () {
@@ -126,7 +126,7 @@ it('can sample', function () {
     report(new MyReportedException());
     report(new MyReportedException());
 
-    expect(Pulse::store())->toEqualWithDelta(1, 4);
+    expect(Pulse::ingest())->toEqualWithDelta(1, 4);
 });
 
 it('can sample at zero', function () {
@@ -143,7 +143,7 @@ it('can sample at zero', function () {
     report(new MyReportedException());
     report(new MyReportedException());
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample at one', function () {
@@ -160,7 +160,7 @@ it('can sample at one', function () {
     report(new MyReportedException());
     report(new MyReportedException());
 
-    expect(Pulse::store())->toBe(10);
+    expect(Pulse::ingest())->toBe(10);
 });
 
 class MyReportedException extends Exception

--- a/tests/Feature/Recorders/QueuesTest.php
+++ b/tests/Feature/Recorders/QueuesTest.php
@@ -37,7 +37,7 @@ it('ingests bus dispatched jobs', function () {
 
     Bus::dispatchToQueue(new MyJob);
 
-    Pulse::store();
+    Pulse::ingest();
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
@@ -56,7 +56,7 @@ it('ingests queued closures', function () {
         throw new RuntimeException('Nope');
     });
 
-    Pulse::store();
+    Pulse::ingest();
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
@@ -71,7 +71,8 @@ it('ingests queued closures', function () {
      * Work the job for the first time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
+
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -85,7 +86,7 @@ it('ingests queued closures', function () {
      * Work the job for the second time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
@@ -107,7 +108,7 @@ it('ingests jobs pushed to the queue', function () {
     Config::set('queue.default', 'database');
 
     Queue::push('MyJob');
-    Pulse::store();
+    Pulse::ingest();
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
@@ -127,7 +128,7 @@ it('ingests queued listeners', function () {
      * Dispatch the event.
      */
     MyEvent::dispatch();
-    Pulse::store();
+    Pulse::ingest();
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
@@ -142,7 +143,7 @@ it('ingests queued listeners', function () {
      * Work the job for the first time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -156,7 +157,7 @@ it('ingests queued listeners', function () {
      * Work the job for the second time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -180,7 +181,7 @@ it('ingests queued mail', function () {
      * Dispatch the mail.
      */
     Mail::to('test@example.com')->queue(new MyMailThatFails);
-    Pulse::store();
+    Pulse::ingest();
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
@@ -195,7 +196,7 @@ it('ingests queued mail', function () {
      * Work the job for the first time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
@@ -210,7 +211,7 @@ it('ingests queued mail', function () {
      * Work the job for the second time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -234,7 +235,7 @@ it('ingests queued notifications', function () {
      * Dispatch the notification.
      */
     Notification::route('mail', 'test@example.com')->notify(new MyNotificationThatFails);
-    Pulse::store();
+    Pulse::ingest();
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
@@ -249,7 +250,7 @@ it('ingests queued notifications', function () {
      * Work the job for the first time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -263,7 +264,7 @@ it('ingests queued notifications', function () {
      * Work the job for the second time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -287,7 +288,7 @@ it('ingests queued commands', function () {
      * Dispatch the command.
      */
     Artisan::queue(MyCommandThatFails::class);
-    Pulse::store();
+    Pulse::ingest();
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
@@ -302,7 +303,7 @@ it('ingests queued commands', function () {
      * Work the job for the first time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -316,7 +317,7 @@ it('ingests queued commands', function () {
      * Work the job for the second time.
      */
     Artisan::call('queue:work', ['--max-jobs' => 1, '--tries' => 2, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -340,9 +341,9 @@ it('handles a job throwing exceptions and failing', function () {
      * Dispatch the job.
      */
     Bus::dispatchToQueue(new MyJobWithMultipleAttemptsThatAlwaysThrows);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -357,7 +358,7 @@ it('handles a job throwing exceptions and failing', function () {
      */
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -372,7 +373,7 @@ it('handles a job throwing exceptions and failing', function () {
      */
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -393,7 +394,7 @@ it('handles a job throwing exceptions and failing', function () {
      */
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -423,9 +424,9 @@ it('handles a failure and then a successful job', function () {
      * Dispatch the job.
      */
     Bus::dispatchToQueue(new MyJobThatPassesOnTheSecondAttempt);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -440,7 +441,7 @@ it('handles a failure and then a successful job', function () {
      */
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -455,7 +456,7 @@ it('handles a failure and then a successful job', function () {
      */
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -479,9 +480,9 @@ it('handles a job that was manually failed', function () {
      * Dispatch the job.
      */
     Bus::dispatchToQueue(new MyJobThatManuallyFails);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -498,7 +499,7 @@ it('handles a job that was manually failed', function () {
     app(ExceptionHandler::class)->reportable(fn (\Throwable $e) => throw $e);
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
     app()->forgetInstance(ExceptionHandler::class);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -516,14 +517,14 @@ it('can ignore jobs', function () {
     ]);
     MyJobThatPassesOnTheSecondAttempt::$attempts = 0;
     Bus::dispatchToQueue(new MyJobThatPassesOnTheSecondAttempt);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
 
     /*
      * Work the job for the first time.
      */
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     expect(queueAggregates())->toHaveCount(0);
 
     /*
@@ -531,7 +532,7 @@ it('can ignore jobs', function () {
      */
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     expect(queueAggregates())->toHaveCount(0);
 });
 
@@ -549,9 +550,9 @@ it('can sample', function () {
     Bus::dispatchToQueue(new MyJob);
     Bus::dispatchToQueue(new MyJob);
     Bus::dispatchToQueue(new MyJob);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(10);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(10));
     expect(queueAggregates()->count())->toEqualWithDelta(1, 4);
 });
 
@@ -570,8 +571,8 @@ it('can sample at zero', function () {
     Bus::dispatchToQueue(new MyJob);
     Bus::dispatchToQueue(new MyJob);
 
-    expect(Queue::size())->toBe(10);
-    expect(Pulse::store())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(10));
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample at one', function () {
@@ -589,8 +590,8 @@ it('can sample at one', function () {
     Bus::dispatchToQueue(new MyJob);
     Bus::dispatchToQueue(new MyJob);
 
-    expect(Queue::size())->toBe(10);
-    expect(Pulse::store())->toBe(10);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(10));
+    expect(Pulse::ingest())->toBe(10);
 });
 
 it("doesn't sample subsequent events for jobs that aren't initially sampled", function () {
@@ -603,9 +604,9 @@ it("doesn't sample subsequent events for jobs that aren't initially sampled", fu
 
     Bus::dispatchToQueue(new MyJobThatAlwaysFails);
     Bus::dispatchToQueue(new MyJobThatAlwaysFails);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(2);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(2));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -616,7 +617,7 @@ it("doesn't sample subsequent events for jobs that aren't initially sampled", fu
     );
 
     Artisan::call('queue:work', ['--tries' => 2, '--max-jobs' => 4, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(16);
     expect($aggregates)->toContainAggregateForAllPeriods(
@@ -638,8 +639,8 @@ it('uses the connection default queue when a job has no queue specified', functi
     Config::set('queue.connections.database.queue', 'custom-default');
 
     Bus::dispatchToQueue(new MyJob);
-    Pulse::store();
-    expect(Queue::size())->toBe(1);
+    Pulse::ingest();
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
 
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(4);

--- a/tests/Feature/Recorders/SlowJobsTest.php
+++ b/tests/Feature/Recorders/SlowJobsTest.php
@@ -22,9 +22,9 @@ it('records slow jobs', function () {
 
     Carbon::setTestNow('2000-01-02 03:04:05');
     Bus::dispatchToQueue(new MySlowJob);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'slow_job')->get()))->toHaveCount(0);
 
     /*
@@ -33,7 +33,7 @@ it('records slow jobs', function () {
 
     Carbon::setTestNow('2000-01-02 03:04:10');
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->get());
     expect($entries)->toHaveCount(1);
     expect($entries[0])->toHaveProperties([
@@ -69,9 +69,9 @@ it('skips jobs under the threshold', function () {
 
     Carbon::setTestNow('2000-01-02 03:04:05');
     Bus::dispatchToQueue(new MySlowJob);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'slow_job')->get()))->toHaveCount(0);
 
     /*
@@ -80,7 +80,7 @@ it('skips jobs under the threshold', function () {
 
     Carbon::setTestNow('2000-01-02 03:04:10');
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->get()))->toHaveCount(0);
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'slow_job')->get()))->toHaveCount(0);
 });
@@ -97,9 +97,9 @@ it('can ignore jobs', function () {
      */
 
     Bus::dispatchToQueue(new MySlowJob);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(1);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'slow_job')->get()))->toHaveCount(0);
 
     /*
@@ -108,7 +108,7 @@ it('can ignore jobs', function () {
 
     Artisan::call('queue:work', ['--max-jobs' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
 
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->get()))->toHaveCount(0);
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'slow_job')->get()))->toHaveCount(0);
 });
@@ -132,9 +132,9 @@ it('can sample', function () {
     Bus::dispatchToQueue(new MySlowJob);
     Bus::dispatchToQueue(new MySlowJob);
     Bus::dispatchToQueue(new MySlowJob);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(10);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(10));
 
     /*
      * Work the jobs.
@@ -142,7 +142,7 @@ it('can sample', function () {
 
     Artisan::call('queue:work', ['--stop-when-empty' => true, '--sleep' => 0]);
 
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->count()))->toEqualWithDelta(1, 4);
 
     Pulse::flush();
@@ -167,9 +167,9 @@ it('can sample at zero', function () {
     Bus::dispatchToQueue(new MySlowJob);
     Bus::dispatchToQueue(new MySlowJob);
     Bus::dispatchToQueue(new MySlowJob);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(10);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(10));
 
     /*
      * Work the jobs.
@@ -177,7 +177,7 @@ it('can sample at zero', function () {
 
     Artisan::call('queue:work', ['--stop-when-empty' => true, '--sleep' => 0]);
 
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->count()))->toBe(0);
 
     Pulse::flush();
@@ -202,9 +202,9 @@ it('can sample at one', function () {
     Bus::dispatchToQueue(new MySlowJob);
     Bus::dispatchToQueue(new MySlowJob);
     Bus::dispatchToQueue(new MySlowJob);
-    Pulse::store();
+    Pulse::ingest();
 
-    expect(Queue::size())->toBe(10);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(10));
 
     /*
      * Work the jobs.
@@ -212,7 +212,7 @@ it('can sample at one', function () {
 
     Artisan::call('queue:work', ['--stop-when-empty' => true, '--sleep' => 0]);
 
-    expect(Queue::size())->toBe(0);
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
     expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->count()))->toBe(10);
 
     Pulse::flush();

--- a/tests/Feature/Recorders/SlowOutgoingRequestsTest.php
+++ b/tests/Feature/Recorders/SlowOutgoingRequestsTest.php
@@ -13,7 +13,7 @@ it('ingests slow outgoing http requests', function () {
     Http::fake(fn () => Http::response('ok'));
 
     Http::get('https://laravel.com');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -48,7 +48,7 @@ it('ignores fast requests', function () {
 
     Http::get('https://laravel.com');
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('captures failed requests', function () {
@@ -57,7 +57,7 @@ it('captures failed requests', function () {
     Http::fake(['https://laravel.com' => Http::response('error', status: 500)]);
 
     Http::get('https://laravel.com');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -75,7 +75,7 @@ it('stores the original URI by default', function () {
     Http::fake(['https://laravel.com*' => Http::response('ok')]);
 
     Http::get('https://laravel.com?foo=123');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -96,7 +96,7 @@ it('can normalize URI', function () {
         '#^https://github\.com/([^/]+)/([^/]+)/commits/([^/]+)$#' => 'github.com/{user}/{repo}/commits/{branch}',
     ]);
     Http::get('https://github.com/laravel/pulse/commits/1.x');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -117,7 +117,7 @@ it('can use back references in normalized URI', function () {
         '#^https?://([^/]+).*$#' => '\1/*',
     ]);
     Http::get('https://github.com/laravel/pulse/commits/1.x');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -139,7 +139,7 @@ it('can provide regex flags in normalization key', function () {
         '/PARAMETER/i' => 'uppercase-parameter',
     ]);
     Http::get('https://github.com?PARAMETER=123');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -160,7 +160,7 @@ it('can ignore outgoing requests', function () {
 
     Http::get('http://127.0.0.1:13714/render');
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample', function () {
@@ -179,7 +179,7 @@ it('can sample', function () {
     Http::get('http://example.com');
     Http::get('http://example.com');
 
-    expect(Pulse::store())->toEqualWithDelta(1, 4);
+    expect(Pulse::ingest())->toEqualWithDelta(1, 4);
 });
 
 it('can sample at zero', function () {
@@ -198,7 +198,7 @@ it('can sample at zero', function () {
     Http::get('http://example.com');
     Http::get('http://example.com');
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample at one', function () {
@@ -217,5 +217,5 @@ it('can sample at one', function () {
     Http::get('http://example.com');
     Http::get('http://example.com');
 
-    expect(Pulse::store())->toBe(10);
+    expect(Pulse::ingest())->toBe(10);
 });

--- a/tests/Feature/Recorders/SlowQueriesTest.php
+++ b/tests/Feature/Recorders/SlowQueriesTest.php
@@ -16,7 +16,7 @@ it('ingests queries', function () {
 
     DB::connection()->statement('select * from users');
 
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -60,7 +60,7 @@ it('can disable capturing the location', function () {
     });
 
     DB::connection()->statement('select * from users');
-    Pulse::store();
+    Pulse::ingest();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
@@ -103,7 +103,7 @@ it('does not ingest queries under the slow query threshold', function () {
     });
 
     DB::table('users')->count();
-    Pulse::store();
+    Pulse::ingest();
 
     Pulse::ignore(fn () => expect(DB::table('pulse_entries')->count())->toBe(0));
 });
@@ -115,7 +115,7 @@ it('ingests queries equal to the slow query threshold', function () {
     });
 
     DB::table('users')->count();
-    Pulse::store();
+    Pulse::ingest();
 
     Pulse::ignore(fn () => expect(DB::table('pulse_entries')->count())->toBe(1));
 });
@@ -127,7 +127,7 @@ it('ingests queries over the slow query threshold', function () {
     });
 
     DB::table('users')->count();
-    Pulse::store();
+    Pulse::ingest();
 
     Pulse::ignore(fn () => expect(DB::table('pulse_entries')->count())->toBe(1));
 });
@@ -138,8 +138,7 @@ it('can ignore queries', function () {
         '/(["`])pulse_[\w]+?\1/', // Pulse tables
     ]);
 
-    expect(Pulse::store())->toBe(0);
-    DB::table('pulse_entries')->count();
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample', function () {
@@ -157,7 +156,7 @@ it('can sample', function () {
     DB::table('users')->count();
     DB::table('users')->count();
 
-    expect(Pulse::store())->toEqualWithDelta(1, 4);
+    expect(Pulse::ingest())->toEqualWithDelta(1, 4);
 });
 
 it('can sample at zero', function () {
@@ -175,7 +174,7 @@ it('can sample at zero', function () {
     DB::table('users')->count();
     DB::table('users')->count();
 
-    expect(Pulse::store())->toBe(0);
+    expect(Pulse::ingest())->toBe(0);
 });
 
 it('can sample at one', function () {
@@ -193,5 +192,5 @@ it('can sample at one', function () {
     DB::table('users')->count();
     DB::table('users')->count();
 
-    expect(Pulse::store())->toBe(10);
+    expect(Pulse::ingest())->toBe(10);
 });

--- a/tests/Feature/RedisTest.php
+++ b/tests/Feature/RedisTest.php
@@ -76,7 +76,7 @@ it('runs the same commands while storing', function ($driver) {
         ->output();
     [$firstEntryKey, $lastEntryKey] = collect(explode("\n", $output))->only([17, 21])->values();
 
-    $commands = captureRedisCommands(fn () => $ingest->store(new StorageFake()));
+    $commands = captureRedisCommands(fn () => $ingest->digest(new StorageFake()));
 
     expect($commands)->toContain('"XRANGE" "laravel_database_laravel:pulse:ingest" "-" "+" "COUNT" "567"');
     expect($commands)->toContain('"XDEL" "laravel_database_laravel:pulse:ingest" "'.$firstEntryKey.'" "'.$lastEntryKey.'"');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -33,13 +33,13 @@ uses(TestCase::class)
         Pulse::flush();
         Pulse::handleExceptionsUsing(fn (Throwable $e) => throw $e);
         Gate::define('viewPulse', fn ($user = null) => true);
-        Config::set('pulse.ingest.trim.lottery', [0, 1]);
+        Config::set('pulse.ingest.trim.lottery', [1, 1]);
     })
     ->afterEach(function () {
         Str::createUuidsNormally();
 
-        if (Pulse::store() > 0) {
-            throw new RuntimeException('The queue is not empty');
+        if (Pulse::wantsIngesting()) {
+            throw new RuntimeException('There are pending entries.');
         }
     })
     ->in('Unit', 'Feature');


### PR DESCRIPTION
This PR addresses memory leaks where Pulse's internal activity creates new entries that are never persisted. It also addresses memory leaks present in the `pulse:work` command.