### PR TITLE
[1.x] Add SQLite support for local environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,8 +85,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3]
+        php: [8.3]
         laravel: [10]
+        stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - PostgreSQL 14
 
@@ -130,9 +131,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.3]
         laravel: [10]
-        stability: [prefer-lowest, prefer-stable]
+        stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - SQLite
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,3 +116,47 @@ jobs:
         env:
           DB_CONNECTION: pgsql
           DB_PASSWORD: password
+
+  sqlite:
+    runs-on: ubuntu-22.04
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.1, 8.2, 8.3]
+        laravel: [10]
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - SQLite
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install redis-cli
+        run: sudo apt-get install -qq redis-tools
+
+      - name: Install dependencies
+        run: |
+           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
+
+      - name: Execute tests
+        run: vendor/bin/pest
+        env:
+          DB_CONNECTION: sqlite

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -23,6 +23,7 @@ return new class extends PulseMigration
             match ($this->driver()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'sqlite' => $table->string('key_hash'),
             };
             $table->mediumText('value');
 
@@ -39,6 +40,7 @@ return new class extends PulseMigration
             match ($this->driver()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'sqlite' => $table->string('key_hash'),
             };
             $table->bigInteger('value')->nullable();
 
@@ -57,6 +59,7 @@ return new class extends PulseMigration
             match ($this->driver()) {
                 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'sqlite' => $table->string('key_hash'),
             };
             $table->string('aggregate');
             $table->decimal('value', 20, 2);

--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -24,7 +24,7 @@ class PulseMigration extends Migration
      */
     protected function shouldRun(): bool
     {
-        if (in_array($this->driver(), ['mysql', 'pgsql'])) {
+        if (in_array($this->driver(), ['mysql', 'pgsql', 'sqlite'])) {
             return true;
         }
 

--- a/tests/Feature/Ingests/DatabaseTest.php
+++ b/tests/Feature/Ingests/DatabaseTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -8,58 +7,111 @@ use Laravel\Pulse\Facades\Pulse;
 use Laravel\Pulse\Storage\DatabaseStorage;
 
 it('trims values at or past expiry', function () {
-    Pulse::stopRecording();
-    Date::setTestNow('2000-01-08 00:00:05');
-    DB::table('pulse_values')->insert([
-        ['type' => 'type', 'key' => 'foo', 'value' => 'value', 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:04')->getTimestamp()],
-        ['type' => 'type', 'key' => 'bar', 'value' => 'value', 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:05')->getTimestamp()],
-        ['type' => 'type', 'key' => 'baz', 'value' => 'value', 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:06')->getTimestamp()],
-    ]);
+    Date::setTestNow('2000-01-01 00:00:04');
+    Pulse::set('type', 'foo', 'value');
+    Date::setTestNow('2000-01-01 00:00:05');
+    Pulse::set('type', 'bar', 'value');
+    Date::setTestNow('2000-01-01 00:00:06');
+    Pulse::set('type', 'baz', 'value');
+    Pulse::store();
 
+    Date::setTestNow('2000-01-08 00:00:05');
     App::make(DatabaseStorage::class)->trim();
 
-    expect(DB::table('pulse_values')->pluck('key')->all())->toBe(['baz']);
+    expect(Pulse::ignore(fn () => DB::table('pulse_values')->pluck('key')->all()))->toBe(['baz']);
 });
 
 it('trims entries at or after week after timestamp', function () {
-    Pulse::stopRecording();
-    Date::setTestNow('2000-01-08 00:00:05');
-    DB::table('pulse_entries')->insert([
-        ['type' => 'foo', 'key' => 'xxxx', 'value' => 1, 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:04')->getTimestamp()],
-        ['type' => 'bar', 'key' => 'xxxx', 'value' => 1, 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:05')->getTimestamp()],
-        ['type' => 'baz', 'key' => 'xxxx', 'value' => 1, 'timestamp' => CarbonImmutable::parse('2000-01-01 00:00:06')->getTimestamp()],
-    ]);
+    Date::setTestNow('2000-01-01 00:00:04');
+    Pulse::record('foo', 'xxxx', 1);
+    Date::setTestNow('2000-01-01 00:00:05');
+    Pulse::record('bar', 'xxxx', 1);
+    Date::setTestNow('2000-01-01 00:00:06');
+    Pulse::record('baz', 'xxxx', 1);
+    Pulse::store();
 
+    Date::setTestNow('2000-01-08 00:00:05');
     App::make(DatabaseStorage::class)->trim();
 
-    expect(DB::table('pulse_entries')->pluck('type')->all())->toBe(['baz']);
+    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->pluck('type')->all()))->toBe(['baz']);
 });
 
-it('trims aggregates once the bucket is no longer relevant', function () {
-    Pulse::stopRecording();
-    Date::setTestNow('2000-01-08 01:01:05');
+it('trims aggregates once the 1 hour bucket is no longer relevant', function () {
+    Date::setTestNow('2000-01-01 00:00:59'); // Bucket: 2000-01-01 00:00:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(1);
 
-    DB::table('pulse_aggregates')->insert([
-        ['period' => 60, 'type' => 'foo:60', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-08 00:01:04')->getTimestamp()],
-        ['period' => 60, 'type' => 'bar:60', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-08 00:01:05')->getTimestamp()],
-        ['period' => 60, 'type' => 'baz:60', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-08 00:01:06')->getTimestamp()],
-        ['period' => 360, 'type' => 'foo:360', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-07 19:01:04')->getTimestamp()],
-        ['period' => 360, 'type' => 'bar:360', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-07 19:01:05')->getTimestamp()],
-        ['period' => 360, 'type' => 'baz:360', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-07 19:01:06')->getTimestamp()],
-        ['period' => 1440, 'type' => 'foo:1440', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-07 01:01:04')->getTimestamp()],
-        ['period' => 1440, 'type' => 'bar:1440', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-07 01:01:05')->getTimestamp()],
-        ['period' => 1440, 'type' => 'baz:1440', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-07 01:01:06')->getTimestamp()],
-        ['period' => 10080, 'type' => 'foo:10080', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-01 01:01:04')->getTimestamp()],
-        ['period' => 10080, 'type' => 'bar:10080', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-01 01:01:05')->getTimestamp()],
-        ['period' => 10080, 'type' => 'baz:10080', 'key' => 'xxxx', 'aggregate' => 'sum', 'value' => 1, 'count' => 1, 'bucket' => CarbonImmutable::parse('2000-01-01 01:01:06')->getTimestamp()],
-    ]);
+    Date::setTestNow('2000-01-01 00:01:00'); // Bucket: 2000-01-01 00:01:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(2);
 
+    Date::setTestNow('2000-01-01 00:59:59'); // 1 second before the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(2);
 
-    expect(DB::table('pulse_aggregates')->pluck('type')->all())->toEqualCanonicalizing([
-        'baz:60',
-        'baz:360',
-        'baz:1440',
-        'baz:10080',
-    ]);
+    Date::setTestNow('2000-01-01 01:00:00'); // The second the oldest bucket become irrelevant.
+    App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(1);
+});
+
+it('trims aggregates once the 6 hour bucket is no longer relevant', function () {
+    Date::setTestNow('2000-01-01 00:05:59'); // Bucket: 2000-01-01 00:00:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(1);
+
+    Date::setTestNow('2000-01-01 00:06:00'); // Bucket: 2000-01-01 00:06:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(2);
+
+    Date::setTestNow('2000-01-01 05:59:59'); // 1 second before the oldest bucket become irrelevant.
+    App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(2);
+
+    Date::setTestNow('2000-01-01 06:00:00'); // The second the oldest bucket become irrelevant.
+    App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(1);
+});
+
+it('trims aggregates once the 24 hour bucket is no longer relevant', function () {
+    Date::setTestNow('2000-01-01 00:23:59'); // Bucket: 2000-01-01 00:00:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(1);
+
+    Date::setTestNow('2000-01-01 00:24:00'); // Bucket: 2000-01-01 00:24:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(2);
+
+    Date::setTestNow('2000-01-01 23:35:59'); // 1 second before the oldest bucket become irrelevant.
+    App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(2);
+
+    Date::setTestNow('2000-01-02 00:00:00'); // The second the oldest bucket become irrelevant.
+    App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(1);
+});
+
+it('trims aggregates once the 7 day bucket is no longer relevant', function () {
+    Date::setTestNow('2000-01-01 02:23:59'); // Bucket: 1999-12-31 23:36:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(1);
+
+    Date::setTestNow('2000-01-01 02:24:00'); // Bucket: 2000-01-01 02:24:00
+    Pulse::record('foo', 'xxxx', 1)->count();
+    Pulse::store();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(2);
+
+    Date::setTestNow('2000-01-07 23:35:59'); // 1 second before the oldest bucket become irrelevant.
+    App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(2);
+
+    Date::setTestNow('2000-01-07 23:36:00'); // The second the oldest bucket become irrelevant.
+    App::make(DatabaseStorage::class)->trim();
+    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(1);
 });

--- a/tests/Feature/Ingests/DatabaseTest.php
+++ b/tests/Feature/Ingests/DatabaseTest.php
@@ -13,12 +13,13 @@ it('trims values at or past expiry', function () {
     Pulse::set('type', 'bar', 'value');
     Date::setTestNow('2000-01-01 00:00:06');
     Pulse::set('type', 'baz', 'value');
-    Pulse::store();
+    Pulse::ingest();
 
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-08 00:00:05');
     App::make(DatabaseStorage::class)->trim();
 
-    expect(Pulse::ignore(fn () => DB::table('pulse_values')->pluck('key')->all()))->toBe(['baz']);
+    expect(DB::table('pulse_values')->pluck('key')->all())->toBe(['baz']);
 });
 
 it('trims entries at or after week after timestamp', function () {
@@ -28,90 +29,95 @@ it('trims entries at or after week after timestamp', function () {
     Pulse::record('bar', 'xxxx', 1);
     Date::setTestNow('2000-01-01 00:00:06');
     Pulse::record('baz', 'xxxx', 1);
-    Pulse::store();
+    Pulse::ingest();
 
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-08 00:00:05');
     App::make(DatabaseStorage::class)->trim();
 
-    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->pluck('type')->all()))->toBe(['baz']);
+    expect(DB::table('pulse_entries')->pluck('type')->all())->toBe(['baz']);
 });
 
 it('trims aggregates once the 1 hour bucket is no longer relevant', function () {
     Date::setTestNow('2000-01-01 00:00:59'); // Bucket: 2000-01-01 00:00:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(1);
 
     Date::setTestNow('2000-01-01 00:01:00'); // Bucket: 2000-01-01 00:01:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(2);
 
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-01 00:59:59'); // 1 second before the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(2);
+    expect(DB::table('pulse_aggregates')->where('period', 60)->count())->toBe(2);
 
     Date::setTestNow('2000-01-01 01:00:00'); // The second the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->count()))->toBe(1);
+    expect(DB::table('pulse_aggregates')->where('period', 60)->count())->toBe(1);
 });
 
 it('trims aggregates once the 6 hour bucket is no longer relevant', function () {
     Date::setTestNow('2000-01-01 00:05:59'); // Bucket: 2000-01-01 00:00:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(1);
 
     Date::setTestNow('2000-01-01 00:06:00'); // Bucket: 2000-01-01 00:06:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(2);
 
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-01 05:59:59'); // 1 second before the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(2);
+    expect(DB::table('pulse_aggregates')->where('period', 360)->count())->toBe(2);
 
     Date::setTestNow('2000-01-01 06:00:00'); // The second the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 360)->count()))->toBe(1);
+    expect(DB::table('pulse_aggregates')->where('period', 360)->count())->toBe(1);
 });
 
 it('trims aggregates once the 24 hour bucket is no longer relevant', function () {
     Date::setTestNow('2000-01-01 00:23:59'); // Bucket: 2000-01-01 00:00:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(1);
 
     Date::setTestNow('2000-01-01 00:24:00'); // Bucket: 2000-01-01 00:24:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(2);
 
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-01 23:35:59'); // 1 second before the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(2);
+    expect(DB::table('pulse_aggregates')->where('period', 1440)->count())->toBe(2);
 
     Date::setTestNow('2000-01-02 00:00:00'); // The second the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 1440)->count()))->toBe(1);
+    expect(DB::table('pulse_aggregates')->where('period', 1440)->count())->toBe(1);
 });
 
 it('trims aggregates once the 7 day bucket is no longer relevant', function () {
     Date::setTestNow('2000-01-01 02:23:59'); // Bucket: 1999-12-31 23:36:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(1);
 
     Date::setTestNow('2000-01-01 02:24:00'); // Bucket: 2000-01-01 02:24:00
     Pulse::record('foo', 'xxxx', 1)->count();
-    Pulse::store();
+    Pulse::ingest();
     expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(2);
 
+    Pulse::stopRecording();
     Date::setTestNow('2000-01-07 23:35:59'); // 1 second before the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(2);
+    expect(DB::table('pulse_aggregates')->where('period', 10080)->count())->toBe(2);
 
     Date::setTestNow('2000-01-07 23:36:00'); // The second the oldest bucket become irrelevant.
     App::make(DatabaseStorage::class)->trim();
-    expect(Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 10080)->count()))->toBe(1);
+    expect(DB::table('pulse_aggregates')->where('period', 10080)->count())->toBe(1);
 });

--- a/tests/Feature/Recorders/SlowRequestsTest.php
+++ b/tests/Feature/Recorders/SlowRequestsTest.php
@@ -40,7 +40,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[0]->aggregate)->toBe('count');
     expect($aggregates[0]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[0]->value)->toBe('1.00');
+    expect($aggregates[0]->value)->toEqual(1);
 
     expect($aggregates[1]->bucket)->toBe(946782240);
     expect($aggregates[1]->period)->toBe(60);
@@ -48,7 +48,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[1]->aggregate)->toBe('max');
     expect($aggregates[1]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[1]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[1]->value)->toBe('4000.00');
+    expect($aggregates[1]->value)->toEqual(4000);
 
     expect($aggregates[2]->bucket)->toBe(946782000);
     expect($aggregates[2]->period)->toBe(360);
@@ -56,7 +56,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[2]->aggregate)->toBe('count');
     expect($aggregates[2]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[2]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[2]->value)->toBe('1.00');
+    expect($aggregates[2]->value)->toEqual(1);
 
     expect($aggregates[3]->bucket)->toBe(946782000);
     expect($aggregates[3]->period)->toBe(360);
@@ -64,7 +64,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[3]->aggregate)->toBe('max');
     expect($aggregates[3]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[3]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[3]->value)->toBe('4000.00');
+    expect($aggregates[3]->value)->toEqual(4000);
 
     expect($aggregates[4]->bucket)->toBe(946781280);
     expect($aggregates[4]->period)->toBe(1440);
@@ -72,7 +72,7 @@ it('captures requests over the threshold', function () {
     expect($aggregates[4]->aggregate)->toBe('count');
     expect($aggregates[4]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[4]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[4]->value)->toBe('1.00');
+    expect($aggregates[4]->value)->toEqual(1);
 
     expect($aggregates[5]->bucket)->toBe(946781280);
     expect($aggregates[5]->period)->toBe(1440);
@@ -80,21 +80,21 @@ it('captures requests over the threshold', function () {
     expect($aggregates[5]->aggregate)->toBe('max');
     expect($aggregates[5]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[5]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[5]->value)->toBe('4000.00');
+    expect($aggregates[5]->value)->toEqual(4000);
 
     expect($aggregates[6]->period)->toBe(10080);
     expect($aggregates[6]->type)->toBe('slow_request');
     expect($aggregates[6]->aggregate)->toBe('count');
     expect($aggregates[6]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[6]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[6]->value)->toBe('1.00');
+    expect($aggregates[6]->value)->toEqual(1);
 
     expect($aggregates[7]->period)->toBe(10080);
     expect($aggregates[7]->type)->toBe('slow_request');
     expect($aggregates[7]->aggregate)->toBe('max');
     expect($aggregates[7]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[7]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[7]->value)->toBe('4000.00');
+    expect($aggregates[7]->value)->toEqual(4000);
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
@@ -126,7 +126,7 @@ it('captures slow requests per user', function () {
     expect($aggregates[0]->aggregate)->toBe('count');
     expect($aggregates[0]->key)->toBe('4321');
     expect($aggregates[0]->key_hash)->toBe(keyHash('4321'));
-    expect($aggregates[0]->value)->toBe('1.00');
+    expect($aggregates[0]->value)->toEqual(1);
 
     expect($aggregates[1]->bucket)->toBe(946782000);
     expect($aggregates[1]->period)->toBe(360);
@@ -134,7 +134,7 @@ it('captures slow requests per user', function () {
     expect($aggregates[1]->aggregate)->toBe('count');
     expect($aggregates[1]->key)->toBe('4321');
     expect($aggregates[1]->key_hash)->toBe(keyHash('4321'));
-    expect($aggregates[1]->value)->toBe('1.00');
+    expect($aggregates[1]->value)->toEqual(1);
 
     expect($aggregates[2]->bucket)->toBe(946781280);
     expect($aggregates[2]->period)->toBe(1440);
@@ -142,14 +142,14 @@ it('captures slow requests per user', function () {
     expect($aggregates[2]->aggregate)->toBe('count');
     expect($aggregates[2]->key)->toBe('4321');
     expect($aggregates[2]->key_hash)->toBe(keyHash('4321'));
-    expect($aggregates[2]->value)->toBe('1.00');
+    expect($aggregates[2]->value)->toEqual(1);
 
     expect($aggregates[3]->period)->toBe(10080);
     expect($aggregates[3]->type)->toBe('slow_user_request');
     expect($aggregates[3]->aggregate)->toBe('count');
     expect($aggregates[3]->key)->toBe('4321');
     expect($aggregates[3]->key_hash)->toBe(keyHash('4321'));
-    expect($aggregates[3]->value)->toBe('1.00');
+    expect($aggregates[3]->value)->toEqual(1);
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
@@ -280,7 +280,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[0]->aggregate)->toBe('count');
     expect($aggregates[0]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[0]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[0]->value)->toBe('1.00');
+    expect($aggregates[0]->value)->toEqual(1);
 
     expect($aggregates[1]->bucket)->toBe(946782240);
     expect($aggregates[1]->period)->toBe(60);
@@ -288,7 +288,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[1]->aggregate)->toBe('max');
     expect($aggregates[1]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[1]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[1]->value)->toBe('4000.00');
+    expect($aggregates[1]->value)->toEqual(4000);
 
     expect($aggregates[2]->bucket)->toBe(946782000);
     expect($aggregates[2]->period)->toBe(360);
@@ -296,7 +296,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[2]->aggregate)->toBe('count');
     expect($aggregates[2]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[2]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[2]->value)->toBe('1.00');
+    expect($aggregates[2]->value)->toEqual(1);
 
     expect($aggregates[3]->bucket)->toBe(946782000);
     expect($aggregates[3]->period)->toBe(360);
@@ -304,7 +304,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[3]->aggregate)->toBe('max');
     expect($aggregates[3]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[3]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[3]->value)->toBe('4000.00');
+    expect($aggregates[3]->value)->toEqual(4000);
 
     expect($aggregates[4]->bucket)->toBe(946781280);
     expect($aggregates[4]->period)->toBe(1440);
@@ -312,7 +312,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[4]->aggregate)->toBe('count');
     expect($aggregates[4]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[4]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[4]->value)->toBe('1.00');
+    expect($aggregates[4]->value)->toEqual(1);
 
     expect($aggregates[5]->bucket)->toBe(946781280);
     expect($aggregates[5]->period)->toBe(1440);
@@ -320,7 +320,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[5]->aggregate)->toBe('max');
     expect($aggregates[5]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[5]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[5]->value)->toBe('4000.00');
+    expect($aggregates[5]->value)->toEqual(4000);
 
     expect($aggregates[6]->bucket)->toBe(946774080);
     expect($aggregates[6]->period)->toBe(10080);
@@ -328,7 +328,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[6]->aggregate)->toBe('count');
     expect($aggregates[6]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[6]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[6]->value)->toBe('1.00');
+    expect($aggregates[6]->value)->toEqual(1);
 
     expect($aggregates[7]->bucket)->toBe(946774080);
     expect($aggregates[7]->period)->toBe(10080);
@@ -336,7 +336,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($aggregates[7]->aggregate)->toBe('max');
     expect($aggregates[7]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[7]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[7]->value)->toBe('4000.00');
+    expect($aggregates[7]->value)->toEqual(4000);
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -135,8 +135,13 @@ it('combines duplicate count aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-    expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
+    } else {
+        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    }
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(3);
@@ -157,8 +162,13 @@ it('combines duplicate min aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-    expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
+    } else {
+        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    }
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(100);
@@ -179,8 +189,13 @@ it('combines duplicate max aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-    expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
+    } else {
+        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    }
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(300);
@@ -201,8 +216,13 @@ it('combines duplicate sum aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-    expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
+    } else {
+        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
+    }
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(600);
@@ -223,8 +243,13 @@ it('combines duplicate average aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-    expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 8 * 4); // 2 entries, 8 columns each, 4 periods
+    } else {
+        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
+        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
+    }
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->get())->keyBy('key');
     expect($aggregates['key1']->value)->toEqual(200);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -103,6 +103,7 @@ function keyHash(string $string): string
     return match (DB::connection()->getDriverName()) {
         'mysql' => hex2bin(md5($string)),
         'pgsql' => Uuid::fromString(md5($string)),
+        'sqlite' => md5($string),
     };
 }
 


### PR DESCRIPTION
This PR introduces SQLite support for Pulse.

**This is intended for local development only,** primarily to prevent any errors when using SQLite for local development or testing, but also to allow developers to have Pulse working locally when setting up authorization gates, custom cards, etc.

Note that SQLite does not appear to include any hashing functions out of the box, so the hash columns must be generated in PHP.