### PR TITLE
[1.x] Support BusyBox/Alpine `top` output

### DIFF
--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -58,7 +58,7 @@ class Servers
 
         $cpu = match (PHP_OS_FAMILY) {
             'Darwin' => (int) `top -l 1 | grep -E "^CPU" | tail -1 | awk '{ print $3 + $5 }'`,
-            'Linux' => (int) `top -bn1 | grep '%Cpu(s)' | tail -1 | grep -Eo '[0-9]+\.[0-9]+' | head -n 4 | tail -1 | awk '{ print 100 - $1 }'`,
+            'Linux' => (int) `top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'`,
             'Windows' => (int) trim(`wmic cpu get loadpercentage | more +1`),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };

--- a/tests/Feature/Recorders/ServersTest.php
+++ b/tests/Feature/Recorders/ServersTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Laravel\Pulse\Events\SharedBeat;
+use Laravel\Pulse\Facades\Pulse;
+use Laravel\Pulse\Recorders\Servers;
+
+it('records server information', function () {
+    Config::set('pulse.recorders.'.Servers::class.'.server_name', 'Foo');
+    Date::setTestNow(Date::now()->startOfMinute());
+    event(app(SharedBeat::class));
+    Pulse::store();
+
+    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->count()))->toBe(0);
+
+    $value = Pulse::ignore(fn () => DB::table('pulse_values')->sole());
+    expect($value->type)->toBe('system');
+    expect($value->key)->toBe('foo');
+    expect($value->timestamp)->toBe(Date::now()->startOfMinute()->timestamp);
+    $payload = json_decode($value->value);
+    expect($payload->name)->toBe('Foo');
+    expect($payload->cpu)->toBeBetween(0, 100);
+    expect($payload->memory_used)->toBeGreaterThan(0);
+    expect($payload->memory_total)->toBeGreaterThan(0);
+
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->get());
+    expect($aggregates->count())->toBe(8);
+    expect($aggregates->pluck('type')->unique()->values()->all())->toBe(['cpu', 'memory']);
+    expect($aggregates->pluck('period')->unique()->values()->all())->toBe([60, 360, 1440, 10080]);
+    expect($aggregates->pluck('key')->unique()->values()->all())->toBe(['foo']);
+    expect($aggregates->pluck('aggregate')->unique()->values()->all())->toBe(['avg']);
+});

--- a/tests/Feature/Recorders/ServersTest.php
+++ b/tests/Feature/Recorders/ServersTest.php
@@ -21,7 +21,8 @@ it('records server information', function () {
     expect($value->timestamp)->toBe(Date::now()->startOfMinute()->timestamp);
     $payload = json_decode($value->value);
     expect($payload->name)->toBe('Foo');
-    expect($payload->cpu)->toBeBetween(0, 100);
+    expect($payload->cpu)->toBeGreaterThanOrEqual(0);
+    expect($payload->cpu)->toBeLessThanOrEqual(100);
     expect($payload->memory_used)->toBeGreaterThan(0);
     expect($payload->memory_total)->toBeGreaterThan(0);
 


### PR DESCRIPTION
This PR updates the servers recorder to work with the output from the `top` command on Alpine Linux (i.e. the BusyBox version) in addition to the "procps-ng" version currently supported.

For reference, the `top` output looks like this with BusyBox:

```sh
Mem: 9138956K used, 1041152K free, 808552K shrd, 419480K buff, 4727092K cached
CPU:  12% usr   2% sys   0% nic  82% idle   0% io   0% irq   0% sirq
Load average: 0.56 0.50 0.47 1/813 116610
```

And this with procps-ng:

```sh
top - 16:18:24 up 2 days,  3:43,  2 users,  load average: 0.90, 1.05, 1.87
Tasks: 586 total,   2 running, 579 sleeping,   0 stopped,   5 zombie
%Cpu(s):  2.1 us,  4.3 sy,  0.0 ni, 93.6 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  31737.7 total,   2068.5 free,  17295.9 used,  14860.7 buff/cache
MiB Swap:   8192.0 total,   5337.0 free,   2855.0 used.  14441.8 avail Mem
```

The updated logic matches the line beginning with either "CPU" or "%Cpu" and then adds the 2nd and 4th fields together (where fields are separated by whitespace).

The logic now much closer matches the macOS version, where the output looks like this:

```sh
Processes: 550 total, 2 running, 548 sleeping, 2647 threads
2023/12/13 13:17:56
Load Avg 2.76, 2.30, 2.21
CPU usage: 8.19% user, 14.75% sys, 77.04% idle
SharedLibs: 692M resident, 136M data, 54M linkedit.
MemRegions: 137385 total, 3879M resident, 472M private, 2790M shared.
PhysMem: 14G used (1766M wired, 603M compressor), 1232M unused.
VM: 215T vsize, 4285M framework vsize, 0(0) swapins, 0(0) swapouts.
Networks: packets: 1972104/1196M in, 2972263/2124M out.
Disks: 748666/10G read, 441407/8478M written.
```

Fixes #207