### PR TITLE
[1.x] Null ingest

### DIFF
--- a/src/Ingests/NullIngest.php
+++ b/src/Ingests/NullIngest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Pulse\Ingests;
+
+use Illuminate\Support\Collection;
+use Laravel\Pulse\Contracts\Ingest;
+use Laravel\Pulse\Contracts\Storage;
+
+class NullIngest implements Ingest
+{
+    /**
+     * Ingest the items.
+     *
+     * @param  \Illuminate\Support\Collection<int, \Laravel\Pulse\Entry>  $items
+     */
+    public function ingest(Collection $items): void
+    {
+        //
+    }
+
+    /**
+     * Digest the ingested items.
+     */
+    public function digest(Storage $storage): int
+    {
+        return 0;
+    }
+
+    /**
+     * Trim the ingest.
+     */
+    public function trim(): void
+    {
+        //
+    }
+}

--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -18,6 +18,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory as ViewFactory;
 use Laravel\Pulse\Contracts\Ingest;
 use Laravel\Pulse\Contracts\Storage;
+use Laravel\Pulse\Ingests\NullIngest;
 use Laravel\Pulse\Ingests\RedisIngest;
 use Laravel\Pulse\Ingests\StorageIngest;
 use Laravel\Pulse\Storage\DatabaseStorage;
@@ -52,6 +53,7 @@ class PulseServiceProvider extends ServiceProvider
         $this->app->bind(Ingest::class, fn (Application $app) => match ($app->make('config')->get('pulse.ingest.driver')) {
             'storage' => $app->make(StorageIngest::class),
             'redis' => $app->make(RedisIngest::class),
+            null, 'null' => $app->make(NullIngest::class),
             default => throw new RuntimeException("Unknown ingest driver [{$app->make('config')->get('pulse.ingest.driver')}]."),
         });
     }


### PR DESCRIPTION
Because Pulse is active in production, it is also good to have it enabled in your testsuite.

This introduces a "null" driver that may be used in testsuites to keep the logic parts of Pulse active, but have the persistence side of things ignored to improve performance of your local testsuite.