### PR TITLE
[1.x] Rename `fields` method and return an object

### DIFF
--- a/src/Contracts/ResolvesUsers.php
+++ b/src/Contracts/ResolvesUsers.php
@@ -20,9 +20,9 @@ interface ResolvesUsers
     public function load(Collection $keys): self;
 
     /**
-     * Eager load the users with the given keys.
+     * Find the user with the given key.
      *
-     * @return array{name: string, extra?: string, avatar?: string}
+     * @return object{name: string, extra?: string, avatar?: string}
      */
-    public function fields(int|string|null $key): array;
+    public function find(int|string|null $key): object;
 }

--- a/src/LegacyUsers.php
+++ b/src/LegacyUsers.php
@@ -44,15 +44,15 @@ class LegacyUsers implements ResolvesUsers
     }
 
     /**
-     * Resolve the user fields for the user with the given key.
+     * Find the user with the given key.
      *
-     * @return array{name: string, extra?: string, avatar?: string}
+     * @return object{name: string, extra?: string, avatar?: string}
      */
-    public function fields(int|string|null $key): array
+    public function find(int|string|null $key): object
     {
         $user = $this->resolvedUsers->firstWhere('id', $key);
 
-        return [
+        return (object) [
             'name' => $user['name'] ?? "ID: $key",
             'extra' => $user['extra'] ?? $user['email'] ?? '',
             'avatar' => $user['avatar'] ?? (($user['email'] ?? false)

--- a/src/Livewire/Usage.php
+++ b/src/Livewire/Usage.php
@@ -56,7 +56,7 @@ class Usage extends Card
 
                 return $counts->map(fn ($row) => (object) [
                     'key' => $row->key,
-                    'user' => (object) $users->fields($row->key),
+                    'user' => $users->find($row->key),
                     'count' => (int) $row->count,
                 ]);
             },

--- a/src/Users.php
+++ b/src/Users.php
@@ -19,7 +19,7 @@ class Users implements ResolvesUsers
     /**
      * The field resolver.
      *
-     * @var ?callable(\Illuminate\Contracts\Auth\Authenticatable): array{name: string, extra?: string, avatar?: string}
+     * @var ?callable(\Illuminate\Contracts\Auth\Authenticatable): object{name: string, extra?: string, avatar?: string}
      */
     protected $fieldResolver = null;
 
@@ -56,19 +56,19 @@ class Users implements ResolvesUsers
     }
 
     /**
-     * Resolve the user fields for the user with the given key.
+     * Find the user with the given key.
      *
-     * @return array{name: string, extra?: string, avatar?: string}
+     * @return object{name: string, extra?: string, avatar?: string}
      */
-    public function fields(int|string|null $key): array
+    public function find(int|string|null $key): object
     {
         $user = $this->resolvedUsers->first(fn ($user) => $user->getAuthIdentifier() == $key);
 
         if ($this->fieldResolver !== null && $user !== null) {
-            return ($this->fieldResolver)($user);
+            return (object) ($this->fieldResolver)($user);
         }
 
-        return [
+        return (object) [
             'name' => $user->name ?? "ID: $key",
             'extra' => $user->email ?? '',
             'avatar' => $user->avatar ?? (($user->email ?? false)
@@ -81,7 +81,7 @@ class Users implements ResolvesUsers
     /**
      * Override the field resolver.
      *
-     * @param  callable(\Illuminate\Contracts\Auth\Authenticatable): array{name: string, extra?: string, avatar?: string}  $resolver
+     * @param  callable(\Illuminate\Contracts\Auth\Authenticatable): object{name: string, extra?: string, avatar?: string}  $resolver
      */
     public function setFieldResolver(callable $resolver): self
     {

--- a/tests/Feature/PulseTest.php
+++ b/tests/Feature/PulseTest.php
@@ -79,12 +79,12 @@ it('resolves users', function () {
 
     $resolved = Pulse::resolveUsers(collect([123, 456]));
 
-    expect($resolved->fields(123))->toBe([
+    expect($resolved->find(123))->toEqual((object) [
         'name' => 'Jess Archer',
         'extra' => 'jess@example.com',
         'avatar' => 'https://gravatar.com/avatar/d72141e224a6aa94fbd060f142e82aaadc05b1fed044017c230ab882523e2673?d=mp',
     ]);
-    expect($resolved->fields(456))->toBe([
+    expect($resolved->find(456))->toEqual((object) [
         'name' => 'Tim MacDonald',
         'extra' => 'tim@example.com',
         'avatar' => 'https://gravatar.com/avatar/8f3b8f8fc3a3ffd7e7d42e0749da576587e4a3a5409c6416439099eeb5b8b67c?d=mp',
@@ -101,9 +101,9 @@ it('can customize the user fields', function () {
         'avatar' => 'https://example.com/avatar.png',
     ]);
 
-    $user = Pulse::resolveUsers(collect([123]))->fields(123);
+    $user = Pulse::resolveUsers(collect([123]))->find(123);
 
-    expect($user)->toBe([
+    expect($user)->toEqual((object) [
         'name' => 'JESS ARCHER',
         'extra' => 11,
         'avatar' => 'https://example.com/avatar.png',
@@ -123,9 +123,9 @@ it('maintains the users method for backwards compatibility', function () {
         ]);
     });
 
-    $user = Pulse::resolveUsers(collect([123]))->fields(123);
+    $user = Pulse::resolveUsers(collect([123]))->find(123);
 
-    expect($user)->toBe([
+    expect($user)->toEqual((object) [
         'name' => 'jess archer',
         'extra' => 11,
         'avatar' => 'https://example.com/avatar.png',
@@ -145,9 +145,9 @@ it('can customize user resolving', function () {
             return $this;
         }
 
-        public function fields(int|string|null $key): array
+        public function find(int|string|null $key): object
         {
-            return [
+            return (object) [
                 'name' => 'Foo',
                 'extra' => $key,
             ];
@@ -159,8 +159,8 @@ it('can customize user resolving', function () {
     expect(Pulse::resolveAuthenticatedUserId())->toBe('["123","456"]');
 
     $users = Pulse::resolveUsers(collect(['["123","456"]']));
-    $user = $users->fields('["123","456"]');
-    expect($user)->toBe([
+    $user = $users->find('["123","456"]');
+    expect($user)->toEqual((object) [
         'name' => 'Foo',
         'extra' => '["123","456"]',
     ]);


### PR DESCRIPTION
This PR makes a minor tweak to the unreleased changes in #251, based on what felt better when writing the docs.

It renames the `fields` method to `find` and returns an object instead of an array because objects feel nicer to work with in Blade views.

**Before**

```php
$users = Pulse::resolveUsers($aggregates->pluck('key'));

$aggregates->map(fn ($aggregate) => (object) [
    'user' => (object) $users->fields($aggregate->key),
    // ...
]);
```

**After**

```php
$users = Pulse::resolveUsers($aggregates->pluck('key'));

$aggregates->map(fn ($aggregate) => (object) [
    'user' => $users->find($aggregate->key),
    // ...
]);
```