### PR TITLE
[1.x] Allow passing user object directly to user card

### DIFF
--- a/resources/views/components/user-card.blade.php
+++ b/resources/views/components/user-card.blade.php
@@ -1,16 +1,20 @@
+@props(['user' => null, 'name' => null, 'extra' => null, 'avatar' => null, 'stats' => null])
+
 <div {{ $attributes->merge(['class' => 'flex items-center justify-between p-3 gap-3 bg-gray-50 dark:bg-gray-800/50 rounded']) }}>
     <div class="flex items-center gap-3 overflow-hidden">
         @if (isset($avatar))
             {{ $avatar }}
+        @elseif ($user->avatar ?? false)
+            <img src="{{ $user->avatar }}" alt="{{ $user->name }}" loading="lazy" class="rounded-full w-8 h-8 object-cover">
         @endif
 
         <div class="overflow-hidden">
-            <div class="text-sm text-gray-900 dark:text-gray-100 font-medium truncate" title="{{ $name }}">
-                {{ $name }}
+            <div class="text-sm text-gray-900 dark:text-gray-100 font-medium truncate" title="{{ $user->name ?? $name }}">
+                {{ $user->name ?? $name }}
             </div>
 
-            <div class="text-xs text-gray-500 dark:text-gray-400 truncate" title="{{ $extra }}">
-                {{ $extra }}
+            <div class="text-xs text-gray-500 dark:text-gray-400 truncate" title="{{ $user->name ?? $extra }}">
+                {{ $user->extra ?? $extra }}
             </div>
         </div>
     </div>

--- a/resources/views/livewire/usage.blade.php
+++ b/resources/views/livewire/usage.blade.php
@@ -39,23 +39,17 @@
             <x-pulse::no-results />
         @else
             <div class="grid grid-cols-1 @lg:grid-cols-2 @3xl:grid-cols-3 @6xl:grid-cols-4 gap-2">
+                @php
+                    $sampleRate = match($this->usage) {
+                        'requests' => $userRequestsConfig['sample_rate'],
+                        'slow_requests' => $slowRequestsConfig['sample_rate'],
+                        'jobs' => $jobsConfig['sample_rate'],
+                    };
+                @endphp
+
                 @foreach ($userRequestCounts as $userRequestCount)
-                    <x-pulse::user-card wire:key="{{ $userRequestCount->key }}" :name="$userRequestCount->user->name" :extra="$userRequestCount->user->extra">
-                        @if ($userRequestCount->user->avatar ?? false)
-                            <x-slot:avatar>
-                                <img src="{{ $userRequestCount->user->avatar }}" loading="lazy" class="rounded-full w-8 h-8 object-cover">
-                            </x-slot:avatar>
-                        @endif
-
+                    <x-pulse::user-card wire:key="{{ $userRequestCount->key }}" :user="$userRequestCount->user">
                         <x-slot:stats>
-                            @php
-                                $sampleRate = match($this->usage) {
-                                    'requests' => $userRequestsConfig['sample_rate'],
-                                    'slow_requests' => $slowRequestsConfig['sample_rate'],
-                                    'jobs' => $jobsConfig['sample_rate'],
-                                };
-                            @endphp
-
                             @if ($sampleRate < 1)
                                 <span title="Sample rate: {{ $sampleRate }}, Raw value: {{ number_format($userRequestCount->count) }}">~{{ number_format($userRequestCount->count * (1 / $sampleRate)) }}</span>
                             @else


### PR DESCRIPTION
This PR updates the `<x-pulse::user-card>` component to accept a Pulse user object (see #257). For backward compatibility, it still accepts the props individually as well.

It will also automatically create the avatar `<img>` tag if it exists on the object, but it can be overridden using the existing `avatar` slot.