### PR TITLE
[1.x] Make `aggregateTotal` return a float when a single type is requested

### DIFF
--- a/src/Contracts/Storage.php
+++ b/src/Contracts/Storage.php
@@ -90,11 +90,11 @@ interface Storage
      *
      * @param  string|list<string>  $types
      * @param  'count'|'min'|'max'|'sum'|'avg'  $aggregate
-     * @return \Illuminate\Support\Collection<string, int>
+     * @return float|\Illuminate\Support\Collection<string, int>
      */
     public function aggregateTotal(
         array|string $types,
         string $aggregate,
         CarbonInterval $interval,
-    ): Collection;
+    ): float|Collection;
 }


### PR DESCRIPTION
This PR improves the return value of the `aggregateTotal` method when only a single type is requested.

```php
$total = Pulse::aggregateTotal('cache_hit', 'count');
```
```
// Before

Illuminate\Support\Collection {
  #items: array:1 [
    "cache_hit" => "12.00"
  ]
}

// After

12.0
```

The current return type is maintained when passing the first parameter as an array of types.