### PR TITLE
[1.x] Prevent `pulse:check` from filling the file cache

### DIFF
--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -67,11 +67,11 @@ class CheckCommand extends Command
 
             $lastSnapshotAt = $now->floorSeconds((int) $interval->totalSeconds);
 
-            $event->dispatch(new SharedBeat($lastSnapshotAt, $interval));
-
             if ($lock && $lock->get()) {
                 $event->dispatch(new IsolatedBeat($lastSnapshotAt, $interval));
             }
+
+            $event->dispatch(new SharedBeat($lastSnapshotAt, $interval));
 
             $pulse->ingest();
         }

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -48,8 +48,8 @@ class CheckCommand extends Command
 
         $lastSnapshotAt = CarbonImmutable::now()->floorSeconds((int) $interval->totalSeconds);
 
-        $lock = $cache->store()->getStore() instanceof LockProvider
-            ? $cache->store()->lock("laravel:pulse:check", (int) $interval->totalSeconds)
+        $lock = ($store = $cache->store()->getStore()) instanceof LockProvider
+            ? $store->lock('laravel:pulse:check', (int) $interval->totalSeconds)
             : null;
 
         while (true) {

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -67,7 +67,7 @@ class CheckCommand extends Command
 
             $lastSnapshotAt = $now->floorSeconds((int) $interval->totalSeconds);
 
-            if ($lock && $lock->get()) {
+            if ($lock?->get()) {
                 $event->dispatch(new IsolatedBeat($lastSnapshotAt, $interval));
             }
 


### PR DESCRIPTION
This PR fixes an issue when using the file cache driver where the cache locks would continue growing on disk. This is due to the file cache driver not automatically removing files when the cache item has expired.

Fixes #238