### PR TITLE
[1.x] Fix helper return

### DIFF
--- a/src/Livewire/Card.php
+++ b/src/Livewire/Card.php
@@ -138,12 +138,12 @@ abstract class Card extends Component
      *
      * @param  string|list<string>  $types
      * @param  'count'|'min'|'max'|'sum'|'avg'  $aggregate
-     * @return \Illuminate\Support\Collection<string, int>
+     * @return float|\Illuminate\Support\Collection<string, int>
      */
     protected function aggregateTotal(
         array|string $types,
         string $aggregate,
-    ): Collection {
+    ): float|Collection {
         return Pulse::aggregateTotal($types, $aggregate, $this->periodAsInterval());
     }
 }


### PR DESCRIPTION
This fixes an issue with the return type on the `aggregateTotal` helper based on the changes in #259.