### PR TITLE
Use (potentially overloaded) key() method for finding user

### DIFF
--- a/src/Users.php
+++ b/src/Users.php
@@ -62,7 +62,7 @@ class Users implements ResolvesUsers
      */
     public function find(int|string|null $key): object
     {
-        $user = $this->resolvedUsers->first(fn ($user) => $this->key($user) === $key);
+        $user = $this->resolvedUsers->first(fn ($user) => $this->key($user) == $key);
 
         if ($this->fieldResolver !== null && $user !== null) {
             return (object) ($this->fieldResolver)($user);

--- a/src/Users.php
+++ b/src/Users.php
@@ -62,7 +62,7 @@ class Users implements ResolvesUsers
      */
     public function find(int|string|null $key): object
     {
-        $user = $this->resolvedUsers->first(fn ($user) => $user->getAuthIdentifier() == $key);
+        $user = $this->resolvedUsers->first(fn ($user) => $this->key($user) === $key);
 
         if ($this->fieldResolver !== null && $user !== null) {
             return (object) ($this->fieldResolver)($user);


### PR DESCRIPTION
This way it is not nessessary to change `find()` method for custom user resolver.