### PR TITLE
Add BSD support for Servers Recorder

### DIFF
--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -46,6 +46,7 @@ class Servers
             'Darwin' => intval(`sysctl hw.memsize | grep -Eo '[0-9]+'` / 1024 / 1024),
             'Linux' => intval(`cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'` / 1024),
             'Windows' => intval(((int) trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`)) / 1024 / 1024),
+            'BSD' => intval(`sysctl hw.physmem | grep -Eo '[0-9]+'` / 1024 / 1024),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
@@ -53,6 +54,7 @@ class Servers
             'Darwin' => $memoryTotal - intval(intval(`vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'`) * intval(`pagesize`) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(`cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'` / 1024), // MB
             'Windows' => $memoryTotal - intval(((int) trim(`wmic OS get FreePhysicalMemory | more +1`)) / 1024), // MB
+            'BSD' => intval(intval(`( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'`) * intval(`pagesize`) / 1024 / 1024), // MB
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
@@ -60,6 +62,7 @@ class Servers
             'Darwin' => (int) `top -l 1 | grep -E "^CPU" | tail -1 | awk '{ print $3 + $5 }'`,
             'Linux' => (int) `top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'`,
             'Windows' => (int) trim(`wmic cpu get loadpercentage | more +1`),
+            'BSD' => (int) `top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'`,
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 


### PR DESCRIPTION
This PR introduces BSD support to record server information:
- CPU usage
- Memory usage

I tested on a real BSD environment and there was some divergencies about how to get the real used memory information. Even though [Zabbix documentation](https://www.zabbix.com/documentation/current/en/manual/appendix/items/vm.memory.size_params) says that `used memory = active + wired + cached` It's not what I have seen on my tests. 

It looks like `active + inactive + cached`  has more accurate values about the used memory, especially when It gets increased.

**PS:** I'm open to fix this in case someone shows me wrong. 