### PR TITLE
[1.x] Remove unused variable declaration

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -66,7 +66,7 @@ class PulseServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if ($enabled = $this->app->make('config')->get('pulse.enabled')) {
+        if ($this->app->make('config')->get('pulse.enabled')) {
             $this->app->make(Pulse::class)->register($this->app->make('config')->get('pulse.recorders'));
             $this->listenForEvents();
         } else {


### PR DESCRIPTION
As `registersRoutes` is a boolean variable, I guess it would be better to change ‍‍‍`registersRoutes` to `isRoutesRegistered` as it conveys the purpose more accurately.
