### PR TITLE
[1.x] Ensure consistent order

### DIFF
--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -37,7 +37,8 @@ class Servers extends Card
                         'updated_at' => $updatedAt = CarbonImmutable::createFromTimestamp($system->timestamp),
                         'recently_reported' => $updatedAt->isAfter(now()->subSeconds(30)),
                     ];
-                });
+                })
+                ->sortBy('name');
         });
 
         if (Livewire::isLivewireRequest()) {

--- a/tests/Feature/Livewire/ServersTest.php
+++ b/tests/Feature/Livewire/ServersTest.php
@@ -59,3 +59,31 @@ it('renders server statistics', function () {
             ],
         ]));
 });
+
+it('sorts by server name', function () {
+    $data = [
+        'memory_used' => 1234,
+        'memory_total' => 2468,
+        'cpu' => 99,
+        'storage' => [
+            ['directory' => '/', 'used' => 123, 'total' => 456],
+        ],
+    ];
+    Pulse::set('system', 'b-web', json_encode([
+        'name' => 'B Web',
+        ...$data,
+    ]));
+    Pulse::set('system', 'a-web', json_encode([
+        'name' => 'A Web',
+        ...$data,
+    ]));
+    Pulse::set('system', 'c-web', json_encode([
+        'name' => 'C Web',
+        ...$data,
+    ]));
+
+    Pulse::ingest();
+
+    Livewire::test(Servers::class, ['lazy' => false])
+        ->assertSeeInOrder(['A Web', 'B Web', 'C Web']);
+});


### PR DESCRIPTION
The ordering of the servers card is not deterministic. This ensures that servers always appear in a consistent and alphabetical order.

fixes https://github.com/laravel/pulse/issues/288