### PR TITLE
Refactor: Use late static binding for improved inheritance in Server recorder class

### DIFF
--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -39,7 +39,7 @@ class Servers
             return;
         }
 
-        $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
+        $server = $this->config->get('pulse.recorders.'.static::class.'.server_name');
         $slug = Str::slug($server);
 
         $memoryTotal = match (PHP_OS_FAMILY) {
@@ -73,7 +73,7 @@ class Servers
             'cpu' => $cpu,
             'memory_used' => $memoryUsed,
             'memory_total' => $memoryTotal,
-            'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType argument.templateType
+            'storage' => collect($this->config->get('pulse.recorders.'.static::class.'.directories')) // @phpstan-ignore argument.templateType argument.templateType
                 ->map(fn (string $directory) => [
                     'directory' => $directory,
                     'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB


### PR DESCRIPTION
**Overview**
This pull request addresses an important improvement in the codebase by refactoring the usage of `self::class` to `static::class` in situations where we want to leverage late static binding. This change ensures greater flexibility, allowing for better inheritance and extension of the Server class.

**Problem Statement**
The current implementation uses `self::class` for obtaining the class name in the record method in `Recorders\Servers`. While this is appropriate in certain scenarios, it limits the ability of child classes to override the record method and inherit the desired behavior with additional functionalities. In this particular case, `self::class` is used to obtain the class name, and it serves as the key in the recorders array in the configuration file (`config/pulse.php`). For example,

```php
// Obtain server_name and directories values from the configuration file
$server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
$directories = $this->config->get('pulse.recorders.'.self::class.'.directories'); 
```
Here, the self::class references the class name where the record method is defined and uses it as the key in the recorders array. Once we override the Server class, we lose access to the key in the recorders array because the Recorders\Server namespace will be replaced with our custom class namespace in the recorders array. This returns null for server_name and directories, affecting metrics display in our dashboard.

I propose replacing instances of self::class with static::class in cases where we anticipate class inheritance. This change allows us to get the class name from which the record method was called, providing access to server_name and directories values from child classes with minimum effort.

Please review the proposed changes and provide feedback. This modification is aimed at improving the extensibility of our code. Thank you!