### PR TITLE
[1.x] Correct queued listeners' "queue" name

### DIFF
--- a/src/Recorders/Queues.php
+++ b/src/Recorders/Queues.php
@@ -137,7 +137,7 @@ class Queues
     protected function resolveQueue(JobReleasedAfterException|JobFailed|JobProcessed|JobProcessing|JobQueued $event): ?string
     {
         return match ($event::class) {
-            JobQueued::class => match(is_object($event->job) ? $event->job::class : $event->job) {
+            JobQueued::class => match (is_object($event->job) ? $event->job::class : $event->job) {
                 CallQueuedListener::class => $this->resolveQueuedListenerQueue($event),
                 default => $event->job->queue ?? null,
             },

--- a/src/Recorders/Queues.php
+++ b/src/Recorders/Queues.php
@@ -146,7 +146,7 @@ class Queues
     }
 
     /**
-     * Resolve the queued listeners queue.
+     * Resolve the queued listener's queue.
      */
     protected function resolveQueuedListenerQueue(JobQueued $event): ?string
     {

--- a/tests/Feature/Recorders/QueuesTest.php
+++ b/tests/Feature/Recorders/QueuesTest.php
@@ -652,6 +652,28 @@ it('uses the connection default queue when a job has no queue specified', functi
     );
 });
 
+it('captures correct queue name for class based queued listeners', function () {
+    Config::set('queue.default', 'database');
+
+    Event::listen('my-event', MyListenerWithCustomQueue::class);
+    Event::listen(MyEvent::class, MyListenerWithCustomQueue::class);
+    Event::listen(MyEvent::class, MyListenerWithViaQueue::class);
+    Event::dispatch('my-event');
+    Event::dispatch(new MyEvent);
+    Pulse::ingest();
+    Artisan::call('queue:work', ['--queue' => 'custom_queue', '--max-jobs' => 3, '--tries' => 1, '--stop-when-empty' => true, '--sleep' => 0]);
+
+    Pulse::ignore(fn () => expect(Queue::size())->toBe(0));
+    $aggregates = queueAggregates();
+    expect($aggregates)->toHaveCount(12);
+    expect($aggregates)->toContainAggregateForAllPeriods(
+        type: ['queued', 'processing', 'processed'],
+        aggregate: 'count',
+        key: 'database:custom_queue',
+        value: '3.00',
+    );
+});
+
 class MyJob implements ShouldQueue
 {
     public function handle()
@@ -745,5 +767,32 @@ class MyJobThatManuallyFails implements ShouldQueue
     public function handle()
     {
         $this->fail();
+    }
+}
+
+class MyListenerWithCustomQueue implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public $queue = 'custom_queue';
+
+    public function handle(): void
+    {
+        //
+    }
+}
+
+class MyListenerWithViaQueue implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public function handle(): void
+    {
+        //
+    }
+
+    public function viaQueue(object $event)
+    {
+        return 'custom_queue';
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -55,7 +55,7 @@ uses(TestCase::class)
 |
 */
 
-expect()->extend('toContainAggregateForAllPeriods', function (string|array $type, string $aggregate, string $key, int $value, ?int $count = null, ?int $timestamp = null) {
+expect()->extend('toContainAggregateForAllPeriods', function (string|array $type, string $aggregate, string $key, int|float|string $value, ?int $count = null, ?int $timestamp = null) {
     $this->toBeInstanceOf(Collection::class);
 
     $values = $this->value->each(function (stdClass $value) {


### PR DESCRIPTION
Fixes https://github.com/laravel/pulse/issues/305

Queued listeners do not have their `$queue` property set. We need to manually resolve the value from the nested listener instance as they are wrapped in a `CallQueuedListener` instance.

This is a similar approach taken in the Event dispatcher class.