### PR TITLE
[1.x] Rework `pulse:check` command

### DIFF
--- a/src/Events/IsolatedBeat.php
+++ b/src/Events/IsolatedBeat.php
@@ -3,7 +3,6 @@
 namespace Laravel\Pulse\Events;
 
 use Carbon\CarbonImmutable;
-use Carbon\CarbonInterval;
 
 class IsolatedBeat
 {
@@ -12,7 +11,6 @@ class IsolatedBeat
      */
     public function __construct(
         public CarbonImmutable $time,
-        public CarbonInterval $interval,
     ) {
         //
     }

--- a/src/Events/SharedBeat.php
+++ b/src/Events/SharedBeat.php
@@ -3,7 +3,6 @@
 namespace Laravel\Pulse\Events;
 
 use Carbon\CarbonImmutable;
-use Carbon\CarbonInterval;
 
 class SharedBeat
 {
@@ -12,7 +11,7 @@ class SharedBeat
      */
     public function __construct(
         public CarbonImmutable $time,
-        public CarbonInterval $interval,
+        public string $instance,
     ) {
         //
     }

--- a/src/Recorders/Concerns/Throttling.php
+++ b/src/Recorders/Concerns/Throttling.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Pulse\Recorders\Concerns;
+
+use Carbon\CarbonImmutable;
+use DateInterval;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\InteractsWithTime;
+use Laravel\Pulse\Events\IsolatedBeat;
+use Laravel\Pulse\Events\SharedBeat;
+use Laravel\Pulse\Support\CacheStoreResolver;
+
+trait Throttling
+{
+    use InteractsWithTime;
+
+    /**
+     * Determine if the recorder is ready to record another snapshot.
+     */
+    protected function throttle(DateInterval|int $interval, SharedBeat|IsolatedBeat $event, callable $callback, ?string $key = null): void
+    {
+        $key ??= static::class;
+
+        if ($event instanceof SharedBeat) {
+            $key = $event->instance.":{$key}";
+        }
+
+        $cache = App::make(CacheStoreResolver::class);
+
+        $key = 'laravel:pulse:throttle:'.$key;
+
+        $lastRunAt = $cache->store()->get($key);
+
+        if ($lastRunAt !== null && CarbonImmutable::createFromTimestamp($lastRunAt)->addSeconds($this->secondsUntil($interval))->isFuture()) {
+            return;
+        }
+
+        $callback($event);
+
+        $cache->store()->put($key, $event->time->getTimestamp(), $interval);
+    }
+}

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -13,6 +13,8 @@ use RuntimeException;
  */
 class Servers
 {
+    use Concerns\Throttling;
+
     /**
      * The events to listen for.
      *
@@ -35,51 +37,49 @@ class Servers
      */
     public function record(SharedBeat $event): void
     {
-        if ($event->time->second % 15 !== 0) {
-            return;
-        }
+        $this->throttle(15, $event, function ($event) {
+            $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
+            $slug = Str::slug($server);
 
-        $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
-        $slug = Str::slug($server);
+            $memoryTotal = match (PHP_OS_FAMILY) {
+                'Darwin' => intval(`sysctl hw.memsize | grep -Eo '[0-9]+'` / 1024 / 1024),
+                'Linux' => intval(`cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'` / 1024),
+                'Windows' => intval(((int) trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`)) / 1024 / 1024),
+                'BSD' => intval(`sysctl hw.physmem | grep -Eo '[0-9]+'` / 1024 / 1024),
+                default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            };
 
-        $memoryTotal = match (PHP_OS_FAMILY) {
-            'Darwin' => intval(`sysctl hw.memsize | grep -Eo '[0-9]+'` / 1024 / 1024),
-            'Linux' => intval(`cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'` / 1024),
-            'Windows' => intval(((int) trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`)) / 1024 / 1024),
-            'BSD' => intval(`sysctl hw.physmem | grep -Eo '[0-9]+'` / 1024 / 1024),
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
-        };
+            $memoryUsed = match (PHP_OS_FAMILY) {
+                'Darwin' => $memoryTotal - intval(intval(`vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'`) * intval(`pagesize`) / 1024 / 1024), // MB
+                'Linux' => $memoryTotal - intval(`cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'` / 1024), // MB
+                'Windows' => $memoryTotal - intval(((int) trim(`wmic OS get FreePhysicalMemory | more +1`)) / 1024), // MB
+                'BSD' => intval(intval(`( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'`) * intval(`pagesize`) / 1024 / 1024), // MB
+                default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            };
 
-        $memoryUsed = match (PHP_OS_FAMILY) {
-            'Darwin' => $memoryTotal - intval(intval(`vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'`) * intval(`pagesize`) / 1024 / 1024), // MB
-            'Linux' => $memoryTotal - intval(`cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'` / 1024), // MB
-            'Windows' => $memoryTotal - intval(((int) trim(`wmic OS get FreePhysicalMemory | more +1`)) / 1024), // MB
-            'BSD' => intval(intval(`( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'`) * intval(`pagesize`) / 1024 / 1024), // MB
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
-        };
+            $cpu = match (PHP_OS_FAMILY) {
+                'Darwin' => (int) `top -l 1 | grep -E "^CPU" | tail -1 | awk '{ print $3 + $5 }'`,
+                'Linux' => (int) `top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'`,
+                'Windows' => (int) trim(`wmic cpu get loadpercentage | more +1`),
+                'BSD' => (int) `top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'`,
+                default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            };
 
-        $cpu = match (PHP_OS_FAMILY) {
-            'Darwin' => (int) `top -l 1 | grep -E "^CPU" | tail -1 | awk '{ print $3 + $5 }'`,
-            'Linux' => (int) `top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'`,
-            'Windows' => (int) trim(`wmic cpu get loadpercentage | more +1`),
-            'BSD' => (int) `top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'`,
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
-        };
-
-        $this->pulse->record('cpu', $slug, $cpu, $event->time)->avg()->onlyBuckets();
-        $this->pulse->record('memory', $slug, $memoryUsed, $event->time)->avg()->onlyBuckets();
-        $this->pulse->set('system', $slug, json_encode([
-            'name' => $server,
-            'cpu' => $cpu,
-            'memory_used' => $memoryUsed,
-            'memory_total' => $memoryTotal,
-            'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType argument.templateType
-                ->map(fn (string $directory) => [
-                    'directory' => $directory,
-                    'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB
-                    'used' => intval(round($total - (disk_free_space($directory) / 1024 / 1024))), // MB
-                ])
-                ->all(),
-        ], flags: JSON_THROW_ON_ERROR), $event->time);
+            $this->pulse->record('cpu', $slug, $cpu, $event->time)->avg()->onlyBuckets();
+            $this->pulse->record('memory', $slug, $memoryUsed, $event->time)->avg()->onlyBuckets();
+            $this->pulse->set('system', $slug, json_encode([
+                'name' => $server,
+                'cpu' => $cpu,
+                'memory_used' => $memoryUsed,
+                'memory_total' => $memoryTotal,
+                'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType argument.templateType
+                    ->map(fn (string $directory) => [
+                        'directory' => $directory,
+                        'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB
+                        'used' => intval(round($total - (disk_free_space($directory) / 1024 / 1024))), // MB
+                    ])
+                    ->all(),
+            ], flags: JSON_THROW_ON_ERROR), $event->time);
+        });
     }
 }

--- a/tests/Feature/Commands/CheckCommandTest.php
+++ b/tests/Feature/Commands/CheckCommandTest.php
@@ -1,0 +1,202 @@
+<?php
+
+use Carbon\CarbonInterval;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Env;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Sleep;
+use Laravel\Pulse\Events\IsolatedBeat;
+use Laravel\Pulse\Events\SharedBeat;
+use Laravel\Pulse\Recorders\Concerns\Throttling;
+
+beforeEach(function () {
+    Carbon::setTestNow(now()->startOfDay());
+});
+
+it('loops when not on vapor', function () {
+    $called = 0;
+    Sleep::fake();
+    Sleep::whenFakingSleep(function () use (&$called) {
+        if ($called > 5) {
+            throw new RuntimeException('bail');
+        }
+    });
+    Event::listen(function (SharedBeat $beat) use (&$called) {
+        $called++;
+    });
+
+    try {
+        Artisan::call('pulse:check');
+    } catch (RuntimeException $e) {
+        if ($e->getMessage() !== 'bail') {
+            throw $e;
+        }
+    }
+
+    expect($called)->toBe(6);
+    Sleep::assertSequence([
+        Sleep::for(1)->second(),
+        Sleep::for(1)->second(),
+        Sleep::for(1)->second(),
+        Sleep::for(1)->second(),
+        Sleep::for(1)->second(),
+        Sleep::for(1)->second(),
+    ]);
+});
+
+it('can run the check command once', function () {
+    Sleep::fake();
+    $called = 0;
+    Event::listen(function (SharedBeat $beat) use (&$called) {
+        $called++;
+    });
+
+    Artisan::call('pulse:check', ['--once' => true]);
+
+    expect($called)->toBe(1);
+    Sleep::assertNeverSlept();
+});
+
+it('exists instead of looping when on vapor', function () {
+    Env::getRepository()->set('VAPOR_SSM_PATH', 1);
+    Sleep::fake();
+    $called = 0;
+    Event::listen(function (SharedBeat $beat) use (&$called) {
+        $called++;
+    });
+
+    Artisan::call('pulse:check');
+
+    expect($called)->toBe(1);
+    Sleep::assertNeverSlept();
+
+    Env::getRepository()->clear('VAPOR_SSM_PATH');
+});
+
+it('can throttle shared beat listeners', function () {
+    $iteration = 1;
+    Event::listen(SharedBeat::class, $listener = new ThrottledBeatListener(CarbonInterval::seconds(3)));
+    Sleep::fake();
+    Sleep::whenFakingSleep(function ($duration) use (&$iteration, $listener) {
+        Carbon::setTestNow(now()->add($duration));
+
+        expect($listener->runs)->toBe(match ($iteration) {
+            1, 2, 3 => 1,
+            4, 5, 6 => 2,
+            7, 8, 9 => 3,
+            10, 11, 12 => 4,
+        });
+
+        if ($iteration === 12) {
+            throw new RuntimeException('bail');
+        }
+
+        $iteration++;
+    });
+
+    try {
+        Artisan::call('pulse:check');
+    } catch (RuntimeException $e) {
+        if ($e->getMessage() !== 'bail') {
+            throw $e;
+        }
+    }
+});
+
+it('can throttle isolated beat listeners', function () {
+    $iteration = 1;
+    Event::listen(IsolatedBeat::class, $listener = new ThrottledBeatListener(interval: 3));
+    Sleep::fake();
+    Sleep::whenFakingSleep(function ($duration) use (&$iteration, $listener) {
+        Carbon::setTestNow(now()->add($duration));
+
+        expect($listener->runs)->toBe(match ($iteration) {
+            1, 2, 3 => 1,
+            4, 5, 6 => 2,
+            7, 8, 9 => 3,
+            10, 11, 12 => 4,
+        });
+
+        if ($iteration === 12) {
+            throw new RuntimeException('bail');
+        }
+
+        $iteration++;
+    });
+
+    try {
+        Artisan::call('pulse:check');
+    } catch (RuntimeException $e) {
+        if ($e->getMessage() !== 'bail') {
+            throw $e;
+        }
+    }
+
+    expect($listener->runs)->toBe(4);
+});
+
+it('does not share throttle locks across check command instances for shared beats', function () {
+    Event::listen(SharedBeat::class, $listener = new ThrottledBeatListener(3));
+
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($listener->runs)->toBe(1);
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($listener->runs)->toBe(2);
+});
+
+it('does share throttle locks across check command instances for shared beats when on vapor', function () {
+    Env::getRepository()->set('VAPOR_SSM_PATH', 1);
+    Event::listen(SharedBeat::class, $listener = new ThrottledBeatListener(3));
+
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($listener->runs)->toBe(1);
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($listener->runs)->toBe(1);
+
+    Env::getRepository()->clear('VAPOR_SSM_PATH');
+});
+
+it('does share throttle locks across instances for IsolatedBeats', function () {
+    Event::listen(IsolatedBeat::class, $listener = new ThrottledBeatListener(3));
+
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($listener->runs)->toBe(1);
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($listener->runs)->toBe(1);
+});
+
+it('only fires isolated beats once per second across check command instances', function () {
+    $called = 0;
+    Event::listen(IsolatedBeat::class, function () use (&$called) {
+        $called++;
+    });
+
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($called)->toBe(1);
+    Carbon::setTestNow(now()->endOfSecond());
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($called)->toBe(1);
+    Carbon::setTestNow(now()->addMillisecond(1));
+    Artisan::call('pulse:check', ['--once' => true]);
+    expect($called)->toBe(2);
+});
+
+class ThrottledBeatListener
+{
+    use Throttling;
+
+    public $runs = 0;
+
+    public function __construct(protected $interval)
+    {
+        //
+    }
+
+    public function __invoke($event)
+    {
+        $this->throttle($this->interval, $event, function () {
+            $this->runs++;
+        });
+    }
+}

--- a/tests/Feature/Recorders/ServersTest.php
+++ b/tests/Feature/Recorders/ServersTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -10,7 +11,7 @@ use Laravel\Pulse\Recorders\Servers;
 it('records server information', function () {
     Config::set('pulse.recorders.'.Servers::class.'.server_name', 'Foo');
     Date::setTestNow(Date::now()->startOfMinute());
-    event(app(SharedBeat::class));
+    event(new SharedBeat(CarbonImmutable::now(), 'instance-id'));
     Pulse::ingest();
 
     expect(Pulse::ignore(fn () => DB::table('pulse_entries')->count()))->toBe(0);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -37,6 +37,7 @@ uses(TestCase::class)
     })
     ->afterEach(function () {
         Str::createUuidsNormally();
+        Sleep::fake(false);
 
         if (Pulse::wantsIngesting()) {
             throw new RuntimeException('There are pending entries.');


### PR DESCRIPTION
The current implementation of the `pulse:check` command is based on our earlier version of Pulse. Due to this, there is a lot of things that feel clunky and don't work as reliably as they could.

This PR rethinks the command and also how recorders that interact with the shared beats can work.

It also allows the command to run a single time when run within a Laravel Vapor's scheduler.

## Improvements

Recorders previously had to do some modulus math if they only wanted to record every now an then. The timeframes were limited to 5 second increments. For example, if we wanted our recorder to take a snapshot every 15 seconds we would do the following...

```php
public function record(SharedBeat $event)
{
    if ($event->time->second % 15 !== 0) {
        return;
    }

    // Record...
}
```

You now may use the much more reliable `Throttling` concern, that ships with Pulse, to throttle recording to a max of every 15 seconds. The throttled duration can now be any arbitrary interval, although the beat will only be triggered roughly once per second.

This makes recording on any given interval much more reliable than it was previously, which could miss intervals if listeners took too long.

```php
use Concerns\Throttling;

public function record(SharedBeat $event)
{
    $this->throttle(15, $event, function () {
        // Record...
    });
}
```

For shared beats this will throttle to the current server. For isolated beats this will throttle across servers.

## Implementation notes

- The `lastSnapshotAt` has been removed. This was not always accurate, and sometimes it was simply a lie. For example, the first time you run the command it will tell you it was run `5` seconds ago, which it was not.
- The 5 second interval is now arbitrary. It was important in our early days, but no longer makes sense.
- The time rounding was important in previous iterations of Pulse, but is no longer relevant.
- The "now" value is captured before we dispatch events, rather than before we potentially sleep. This was just bad regardless.
- Beats are now triggered roughly once a second.