### PR TITLE
[1.x] Ignore offline servers

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -165,6 +165,7 @@ return [
         Recorders\Servers::class => [
             'server_name' => env('PULSE_SERVER_NAME', gethostname()),
             'ignore_offline' => env('PULSE_SERVER_IGNORE_OFFLINE', false),
+            'ignore_offline_after' => env('PULSE_SERVER_IGNORE_OFFLINE_AFTER', 2),
             'directories' => explode(':', env('PULSE_SERVER_DIRECTORIES', '/')),
         ],
 

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -165,7 +165,7 @@ return [
         Recorders\Servers::class => [
             'server_name' => env('PULSE_SERVER_NAME', gethostname()),
             'ignore_offline' => env('PULSE_SERVER_IGNORE_OFFLINE', false),
-            'ignore_offline_after' => env('PULSE_SERVER_IGNORE_OFFLINE_AFTER', 2),
+            'ignore_offline_after' => env('PULSE_SERVER_IGNORE_OFFLINE_AFTER', 0),
             'directories' => explode(':', env('PULSE_SERVER_DIRECTORIES', '/')),
         ],
 

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -164,6 +164,7 @@ return [
 
         Recorders\Servers::class => [
             'server_name' => env('PULSE_SERVER_NAME', gethostname()),
+            'ignore_offline' => env('PULSE_SERVER_IGNORE_OFFLINE', false),
             'directories' => explode(':', env('PULSE_SERVER_DIRECTORIES', '/')),
         ],
 

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -7,6 +7,8 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\View;
 use Livewire\Attributes\Lazy;
 use Livewire\Livewire;
+use Illuminate\Support\Facades\Config;
+use Laravel\Pulse\Recorders\Servers as ServersRecorder;
 
 /**
  * @internal
@@ -25,6 +27,10 @@ class Servers extends Card
             return $this->values('system')
                 ->map(function ($system, $slug) use ($graphs) {
                     $values = json_decode($system->value, flags: JSON_THROW_ON_ERROR);
+                    if (!CarbonImmutable::createFromTimestamp($system->timestamp)->isAfter(now()->subSeconds(30)) && Config::get('pulse.recorders.' . ServersRecorder::class . '.ignore_offline')) {
+                        //instead of returning null, we remove the value from the list
+                        return null;
+                    }
 
                     return (object) [
                         'name' => (string) $values->name,
@@ -38,6 +44,7 @@ class Servers extends Card
                         'recently_reported' => $updatedAt->isAfter(now()->subSeconds(30)),
                     ];
                 })
+                ->filter()
                 ->sortBy('name');
         });
 

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -27,7 +27,7 @@ class Servers extends Card
             return $this->values('system')
                 ->map(function ($system, $slug) use ($graphs) {
                     $values = json_decode($system->value, flags: JSON_THROW_ON_ERROR);
-                    if (!CarbonImmutable::createFromTimestamp($system->timestamp)->isAfter(now()->subSeconds(30)) && Config::get('pulse.recorders.' . ServersRecorder::class . '.ignore_offline')) {
+                    if (!CarbonImmutable::createFromTimestamp($system->timestamp)->isAfter(now()->subSeconds(30)) && Config::get('pulse.recorders.' . ServersRecorder::class . '.ignore_offline', false)) {
                         //instead of returning null, we remove the value from the list
                         return null;
                     }

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -27,7 +27,7 @@ class Servers extends Card
             return $this->values('system')
                 ->map(function ($system, $slug) use ($graphs) {
                     $values = json_decode($system->value, flags: JSON_THROW_ON_ERROR);
-                    if (!CarbonImmutable::createFromTimestamp($system->timestamp)->isAfter(now()->subSeconds(30)) && Config::get('pulse.recorders.' . ServersRecorder::class . '.ignore_offline', false)) {
+                    if (!CarbonImmutable::createFromTimestamp($system->timestamp)->isAfter(now()->subSeconds(30)->subMinutes(Config::get('pulse.recorders.'.ServersRecorder::class . '.ignore_offline_after', 0))) && Config::get('pulse.recorders.' . ServersRecorder::class . '.ignore_offline', false)) {
                         //instead of returning null, we remove the value from the list
                         return null;
                     }


### PR DESCRIPTION
## This PR adds the option to ignore offline servers.
Based on #315 

The PR adds a config option, to the Servers recorder, and changes the Servers Livewire card, to remove offline servers if the config option is enabled.

Added options:
PULSE_SERVER_IGNORE_OFFLINE - when true, offline servers will be hidden
PULSE_SERVER_IGNORE_OFFLINE_AFTER - when specified, offline servers will be hidden after the specified time (in minutes). Just specifying this value, will not hide offline servers, unless the other value is set to true.



Tested on a multi server k8s setup, and seems to work as expected.

### Issue description
When deploying an app that uses Pulse on Kubernetes, after every deployment, the Pulse page will be cluttered by a bunch of offline servers.
These servers remain visible, even after the selected timeframe (1H,6H...) does not have any data from the server.
Example screenshot:
![image](https://github.com/laravel/pulse/assets/64219099/13a6bb52-81b0-4a68-b27e-6b4ab564c99d)

If the config option is enabled, the servers page will show only online servers:
<img width="1208" alt="image" src="https://github.com/laravel/pulse/assets/64219099/fa2ac650-7c91-4cb0-ba1d-724b8bd213b0">
