### PR TITLE
[1.x] Fix trimming direct to storage ingest

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -311,7 +311,7 @@ class Pulse
             $odds = $this->app->make('config')->get('pulse.ingest.trim.lottery') ?? $this->app->make('config')->get('pulse.ingest.trim_lottery');
 
             Lottery::odds(...$odds)
-                ->winner(fn () => $this->rescue(fn () => $ingest->trim(...)))
+                ->winner(fn () => $this->rescue($ingest->trim(...)))
                 ->choose();
 
             $this->flush();

--- a/tests/Feature/PulseTest.php
+++ b/tests/Feature/PulseTest.php
@@ -34,6 +34,17 @@ it('can filter records', function () {
     expect($storage->stored[1]->key)->toBe('keep');
 });
 
+it('can trim records', function () {
+    App::instance(Storage::class, $storage = new StorageFake);
+
+    Pulse::record('foo', 'delete', 0, now()->subMonth());
+    Pulse::record('foo', 'keep', 0);
+
+    Pulse::ingest();
+
+    expect($storage->stored)->toHaveCount(1);
+});
+
 it('can lazily capture entries', function () {
     App::instance(Storage::class, $storage = new StorageFake);
 

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -481,4 +481,4 @@ it('collapses values with the same key into a single upsert', function () {
     $values = Pulse::ignore(fn () => DB::table('pulse_values')->get());
     expect($values)->toHaveCount(1);
     expect($values[0]->value)->toBe('345');
-})->only();
+});

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -123,9 +123,12 @@ test('aggregation', function () {
 });
 
 it('combines duplicate count aggregates before upserting', function () {
-    Config::set('pulse.ingest.trim.lottery', [0, 1]);
     $queries = collect();
-    DB::listen(fn ($query) => $queries[] = $query);
+    DB::listen(function (QueryExecuted $event) use (&$queries) {
+        if (str_starts_with($event->sql, 'insert')) {
+            $queries[] = $event;
+        }
+    });
 
     Pulse::record('type', 'key1')->count();
     Pulse::record('type', 'key1')->count();
@@ -150,9 +153,12 @@ it('combines duplicate count aggregates before upserting', function () {
 });
 
 it('combines duplicate min aggregates before upserting', function () {
-    Config::set('pulse.ingest.trim.lottery', [0, 1]);
     $queries = collect();
-    DB::listen(fn ($query) => $queries[] = $query);
+    DB::listen(function (QueryExecuted $event) use (&$queries) {
+        if (str_starts_with($event->sql, 'insert')) {
+            $queries[] = $event;
+        }
+    });
 
     Pulse::record('type', 'key1', 200)->min();
     Pulse::record('type', 'key1', 100)->min();
@@ -177,9 +183,12 @@ it('combines duplicate min aggregates before upserting', function () {
 });
 
 it('combines duplicate max aggregates before upserting', function () {
-    Config::set('pulse.ingest.trim.lottery', [0, 1]);
     $queries = collect();
-    DB::listen(fn ($query) => $queries[] = $query);
+    DB::listen(function (QueryExecuted $event) use (&$queries) {
+        if (str_starts_with($event->sql, 'insert')) {
+            $queries[] = $event;
+        }
+    });
 
     Pulse::record('type', 'key1', 100)->max();
     Pulse::record('type', 'key1', 300)->max();
@@ -204,9 +213,12 @@ it('combines duplicate max aggregates before upserting', function () {
 });
 
 it('combines duplicate sum aggregates before upserting', function () {
-    Config::set('pulse.ingest.trim.lottery', [0, 1]);
     $queries = collect();
-    DB::listen(fn ($query) => $queries[] = $query);
+    DB::listen(function (QueryExecuted $event) use (&$queries) {
+        if (str_starts_with($event->sql, 'insert')) {
+            $queries[] = $event;
+        }
+    });
 
     Pulse::record('type', 'key1', 100)->sum();
     Pulse::record('type', 'key1', 300)->sum();
@@ -231,9 +243,12 @@ it('combines duplicate sum aggregates before upserting', function () {
 });
 
 it('combines duplicate average aggregates before upserting', function () {
-    Config::set('pulse.ingest.trim.lottery', [0, 1]);
     $queries = collect();
-    DB::listen(fn ($query) => $queries[] = $query);
+    DB::listen(function (QueryExecuted $event) use (&$queries) {
+        if (str_starts_with($event->sql, 'insert')) {
+            $queries[] = $event;
+        }
+    });
 
     Pulse::record('type', 'key1', 100)->avg();
     Pulse::record('type', 'key1', 300)->avg();
@@ -464,10 +479,11 @@ test('total aggregate for multiple types', function () {
 });
 
 it('collapses values with the same key into a single upsert', function () {
-    Config::set('pulse.ingest.trim.lottery', [0, 1]);
     $bindings = [];
     DB::listen(function (QueryExecuted $event) use (&$bindings) {
-        $bindings = $event->bindings;
+        if (str_starts_with($event->sql, 'insert')) {
+            $bindings = $event->bindings;
+        }
     });
 
     Pulse::set('read_counter', 'post:321', 123);

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -464,6 +464,7 @@ test('total aggregate for multiple types', function () {
 });
 
 it('collapses values with the same key into a single upsert', function () {
+    Config::set('pulse.ingest.trim.lottery', [0, 1]);
     $bindings = [];
     DB::listen(function (QueryExecuted $event) use (&$bindings) {
         $bindings = $event->bindings;
@@ -480,4 +481,4 @@ it('collapses values with the same key into a single upsert', function () {
     $values = Pulse::ignore(fn () => DB::table('pulse_values')->get());
     expect($values)->toHaveCount(1);
     expect($values[0]->value)->toBe('345');
-});
+})->only();

--- a/tests/StorageFake.php
+++ b/tests/StorageFake.php
@@ -31,7 +31,7 @@ class StorageFake implements Storage
      */
     public function trim(): void
     {
-        //
+        $this->stored = $this->stored->reject(fn($record) => $record->timestamp < now()->subWeek()->timestamp);
     }
 
     /**

--- a/tests/StorageFake.php
+++ b/tests/StorageFake.php
@@ -31,7 +31,7 @@ class StorageFake implements Storage
      */
     public function trim(): void
     {
-        $this->stored = $this->stored->reject(fn($record) => $record->timestamp < now()->subWeek()->timestamp);
+        $this->stored = $this->stored->reject(fn($record) => $record->timestamp <= now()->subWeek()->timestamp);
     }
 
     /**


### PR DESCRIPTION
Currently pulse does not actually trim records. This is due to an accidental double clousure call in Pulse::ingest(). It uses both `fn() => ` and `$this->trim(...)` causing a double closure, which is then called, resulting in trim never getting called.

```php
//before
->winner(fn () => $this->rescue(fn () => $ingest->trim(...)))
//after
->winner(fn () => $this->rescue($ingest->trim(...)))
```

Reported here.
https://github.com/laravel/pulse/issues/317
