### PR TITLE
limit sql length to avoid breaking the json

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -196,7 +196,7 @@ return [
             'threshold' => env('PULSE_SLOW_QUERIES_THRESHOLD', 1000),
             'location' => env('PULSE_SLOW_QUERIES_LOCATION', true),
             'highlighting' => env('PULSE_SLOW_QUERIES_HIGHLIGHTING', true),
-            'max_sql_length' => env('PULSE_SLOW_QUERIES_MAX_SQL_LENGTH', null),
+            'max_query_length' => env('PULSE_SLOW_QUERIES_MAX_QUERY_LENGTH', null),
             'ignore' => [
                 '/(["`])pulse_[\w]+?\1/', // Pulse tables...
                 '/(["`])telescope_[\w]+?\1/', // Telescope tables...

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -196,6 +196,7 @@ return [
             'threshold' => env('PULSE_SLOW_QUERIES_THRESHOLD', 1000),
             'location' => env('PULSE_SLOW_QUERIES_LOCATION', true),
             'highlighting' => env('PULSE_SLOW_QUERIES_HIGHLIGHTING', true),
+            'max_sql_length' => env('PULSE_SLOW_QUERIES_MAX_SQL_LENGTH', null),
             'ignore' => [
                 '/(["`])pulse_[\w]+?\1/', // Pulse tables...
                 '/(["`])telescope_[\w]+?\1/', // Telescope tables...

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -55,9 +55,13 @@ class SlowQueries
                 return;
             }
 
+            if ($maxSqlLength = $this->config->get('pulse.recorders.'.self::class.'.max_sql_length')) {
+                $sql = Str::limit($sql, $maxSqlLength);
+            }
+
             $this->pulse->record(
                 type: 'slow_query',
-                key: json_encode([Str::limit($sql, 65000), $location], flags: JSON_THROW_ON_ERROR),
+                key: json_encode([$sql, $location], flags: JSON_THROW_ON_ERROR),
                 value: $duration,
                 timestamp: (int) (($timestampMs - $duration) / 1000),
             )->max()->count();

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -55,8 +55,8 @@ class SlowQueries
                 return;
             }
 
-            if ($maxSqlLength = $this->config->get('pulse.recorders.'.self::class.'.max_sql_length')) {
-                $sql = Str::limit($sql, $maxSqlLength);
+            if ($maxQueryLength = $this->config->get('pulse.recorders.'.self::class.'.max_query_length')) {
+                $sql = Str::limit($sql, $maxQueryLength);
             }
 
             $this->pulse->record(

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -57,7 +57,7 @@ class SlowQueries
 
             $this->pulse->record(
                 type: 'slow_query',
-                key: json_encode([$sql, $location], flags: JSON_THROW_ON_ERROR),
+                key: json_encode([Str::limit($sql, 65000), $location], flags: JSON_THROW_ON_ERROR),
                 value: $duration,
                 timestamp: (int) (($timestampMs - $duration) / 1000),
             )->max()->count();


### PR DESCRIPTION
### Issue
We've identified a bug within Laravel Pulse where if the slow query detector captures an excessively large SQL statement, it leads to a disruption in the JSON schema stored in the database. This disruption makes it impossible to read the affected data, impacting the tool's ability to provide accurate insights into application performance.

### Root Cause
The root cause of this issue lies in the default length of the database column designated for storing SQL statements. When a captured SQL statement exceeds this default length (65535), the resulting JSON encoding process creates a payload that violates the column's size constraints, leading to corruption of the JSON schema and subsequent data retrieval problems.

### Proposed Solution
To address this issue, I propose implementing a check to truncate SQL statements to a maximum character length before encoding them into JSON. This approach ensures that the payload size remains within the database field size constraints, thus preserving the integrity of the JSON schema.

### Changes Made
Start using `Str::limit($sql, 65000)` to make sure we are not getting too close to the limit.

### Impact
This fix ensures that Laravel Pulse can handle large SQL statements without compromising the JSON schema's integrity in the database, thereby maintaining the tool's efficacy in providing performance insights.