### PR TITLE
[1.x] Add `mariadb` driver support plus Laravel 11 CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10]
+        laravel: [10, 11]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - MySQL 5.7
@@ -85,7 +85,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3]
-        laravel: [10]
+        laravel: [11]
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - MariaDB 10.5
@@ -139,7 +139,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3]
-        laravel: [10]
+        laravel: [11]
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - PostgreSQL 14
@@ -185,7 +185,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3]
-        laravel: [10]
+        laravel: [11]
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - SQLite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,10 @@ jobs:
       mysql:
         image: mysql:5.7
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: forge
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_DATABASE: pulse
+          MYSQL_USER: pulse
+          MYSQL_PASSWORD: password
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -61,17 +63,22 @@ jobs:
         run: vendor/bin/pest
         env:
           DB_CONNECTION: mysql
-          DB_USERNAME: root
+          DB_DATABASE: pulse
+          DB_USERNAME: pulse
+          DB_PASSWORD: password
+          DB_COLLATION: utf8mb4_unicode_ci
 
   mariadb:
     runs-on: ubuntu-22.04
 
     services:
       mysql:
-        image: mariadb:10.5
+        image: mariadb:10
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: forge
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_DATABASE: pulse
+          MYSQL_USER: pulse
+          MYSQL_PASSWORD: password
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -88,7 +95,7 @@ jobs:
         laravel: [11]
         stability: [prefer-stable]
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - MariaDB 10.5
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - MariaDB 10
 
     steps:
       - name: Checkout code
@@ -113,8 +120,10 @@ jobs:
       - name: Execute tests
         run: vendor/bin/pest
         env:
-          DB_CONNECTION: mysql
-          DB_USERNAME: root
+          DB_CONNECTION: mariadb
+          DB_DATABASE: pulse
+          DB_USERNAME: pulse
+          DB_PASSWORD: password
 
   pgsql:
     runs-on: ubuntu-22.04
@@ -123,8 +132,8 @@ jobs:
       postgresql:
         image: postgres:14
         env:
-          POSTGRES_DB: forge
-          POSTGRES_USER: forge
+          POSTGRES_DB: pulse
+          POSTGRES_USER: pulse
           POSTGRES_PASSWORD: password
         ports:
           - 5432:5432
@@ -169,6 +178,8 @@ jobs:
         run: vendor/bin/pest
         env:
           DB_CONNECTION: pgsql
+          DB_DATABASE: pulse
+          DB_USERNAME: pulse
           DB_PASSWORD: password
 
   sqlite:

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -21,7 +21,7 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -38,7 +38,7 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -57,7 +57,7 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -182,7 +182,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mysql' => new Expression('`value` + values(`value`)'),
+                    'mariadb', 'mysql' => new Expression('`value` + values(`value`)'),
                     'pgsql', 'sqlite' => new Expression('"pulse_aggregates"."value" + "excluded"."value"'),
                     default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
                 },
@@ -202,7 +202,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mysql' => new Expression('least(`value`, values(`value`))'),
+                    'mariadb', 'mysql' => new Expression('least(`value`, values(`value`))'),
                     'pgsql' => new Expression('least("pulse_aggregates"."value", "excluded"."value")'),
                     'sqlite' => new Expression('min("pulse_aggregates"."value", "excluded"."value")'),
                     default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
@@ -223,7 +223,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mysql' => new Expression('greatest(`value`, values(`value`))'),
+                    'mariadb', 'mysql' => new Expression('greatest(`value`, values(`value`))'),
                     'pgsql' => new Expression('greatest("pulse_aggregates"."value", "excluded"."value")'),
                     'sqlite' => new Expression('max("pulse_aggregates"."value", "excluded"."value")'),
                     default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
@@ -244,7 +244,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mysql' => new Expression('`value` + values(`value`)'),
+                    'mariadb', 'mysql' => new Expression('`value` + values(`value`)'),
                     'pgsql', 'sqlite' => new Expression('"pulse_aggregates"."value" + "excluded"."value"'),
                     default => throw new RuntimeException("Unsupported database driver [{$driver}]"),
                 },
@@ -263,7 +263,7 @@ class DatabaseStorage implements Storage
             $values,
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             match ($driver = $this->connection()->getDriverName()) {
-                'mysql' => [
+                'mariadb', 'mysql' => [
                     'value' => new Expression('(`value` * `count` + (values(`value`) * values(`count`))) / (`count` + values(`count`))'),
                     'count' => new Expression('`count` + values(`count`)'),
                 ],

--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -24,7 +24,7 @@ class PulseMigration extends Migration
      */
     protected function shouldRun(): bool
     {
-        if (in_array($this->driver(), ['mysql', 'pgsql', 'sqlite'])) {
+        if (in_array($this->driver(), ['mariadb', 'mysql', 'pgsql', 'sqlite'])) {
             return true;
         }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -102,7 +102,7 @@ expect()->extend('toContainAggregateForAllPeriods', function (string|array $type
 function keyHash(string $string): string
 {
     return match (DB::connection()->getDriverName()) {
-        'mysql' => hex2bin(md5($string)),
+        'mariadb', 'mysql' => hex2bin(md5($string)),
         'pgsql' => Uuid::fromString(md5($string)),
         'sqlite' => md5($string),
     };


### PR DESCRIPTION
GitHub actions had started failing, which appears to be because we were relying on default `DB_` env vars and/or default config file vars which have changed.

This PR:
* Makes the DB auth settings explicit in CI rather than relying on defaults.
* Adds Laravel 11 to the matrix
* Adds support for the `mariadb` database driver, which, in addition to being nice to have, also solved an issue with different default collations.