### PR TITLE
[1.x] Freeze time to fix flakey tests

### DIFF
--- a/tests/Feature/Recorders/QueuesTest.php
+++ b/tests/Feature/Recorders/QueuesTest.php
@@ -382,7 +382,6 @@ it('handles a job throwing exceptions and failing', function () {
     Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
-    // Fail...
     expect($aggregates)->toContainAggregateForAllPeriods(
         type: 'queued',
         aggregate: 'count',

--- a/tests/Feature/Recorders/QueuesTest.php
+++ b/tests/Feature/Recorders/QueuesTest.php
@@ -20,6 +20,8 @@ use Illuminate\Support\Str;
 use Laravel\Pulse\Facades\Pulse;
 use Laravel\Pulse\Recorders\Queues;
 
+use function Pest\Laravel\freezeTime;
+
 function queueAggregates()
 {
     return Pulse::ignore(fn () => DB::table('pulse_aggregates')->whereIn('type', [
@@ -31,6 +33,10 @@ function queueAggregates()
         'slow_job',
     ])->get());
 }
+
+beforeEach(function () {
+    freezeTime();
+});
 
 it('ingests bus dispatched jobs', function () {
     Config::set('queue.default', 'database');
@@ -376,6 +382,7 @@ it('handles a job throwing exceptions and failing', function () {
     Pulse::ignore(fn () => expect(Queue::size())->toBe(1));
     $aggregates = queueAggregates();
     expect($aggregates)->toHaveCount(12);
+    // Fail...
     expect($aggregates)->toContainAggregateForAllPeriods(
         type: 'queued',
         aggregate: 'count',


### PR DESCRIPTION
The queue tests can sometimes take a little while, esp. because we spin up a queue worker.

This means that sometimes the current "bucket" would change within the test and cause failures in CI, i.e., we have flakey tests.

This fixes that by freezing time across the board for the queues' tests. We may want to roll this our further, but for now it fixes what we know is causing us issues.