### PR TITLE
[1.x] Customise server stats

### DIFF
--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -59,7 +59,7 @@ class Servers
     /**
      * Detect memory via the given callback.
      *
-     * @param  null|(callable(): array{total: int, used: int})   $callback
+     * @param  null|(callable(): array{total: int, used: int})  $callback
      */
     public static function detectMemoryUsing(?callable $callback)
     {
@@ -130,7 +130,7 @@ class Servers
             'Linux' => intval(`cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'` / 1024),
             'Windows' => intval(((int) trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`)) / 1024 / 1024),
             'BSD' => intval(`sysctl hw.physmem | grep -Eo '[0-9]+'` / 1024 / 1024),
-default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         $memoryUsed = match (PHP_OS_FAMILY) {
@@ -138,7 +138,7 @@ default => throw new RuntimeException('The pulse:check command does not currentl
             'Linux' => $memoryTotal - intval(`cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'` / 1024), // MB
             'Windows' => $memoryTotal - intval(((int) trim(`wmic OS get FreePhysicalMemory | more +1`)) / 1024), // MB
             'BSD' => intval(intval(`( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'`) * intval(`pagesize`) / 1024 / 1024), // MB
-default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         return [

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -51,7 +51,7 @@ class Servers
      *
      * @param  null|(callable(): int)  $callback
      */
-    public static function detectCpuUsing(?callable $callback)
+    public static function detectCpuUsing(?callable $callback): void
     {
         self::$detectCpuUsing = $callback;
     }
@@ -61,7 +61,7 @@ class Servers
      *
      * @param  null|(callable(): array{total: int, used: int})  $callback
      */
-    public static function detectMemoryUsing(?callable $callback)
+    public static function detectMemoryUsing(?callable $callback): void
     {
         self::$detectMemoryUsing = $callback;
     }

--- a/tests/Feature/Recorders/ServersTest.php
+++ b/tests/Feature/Recorders/ServersTest.php
@@ -34,3 +34,31 @@ it('records server information', function () {
     expect($aggregates->pluck('key')->unique()->values()->all())->toBe(['foo']);
     expect($aggregates->pluck('aggregate')->unique()->values()->all())->toBe(['avg']);
 });
+
+it('can customise CPU and memory resolution', function () {
+    Config::set('pulse.recorders.'.Servers::class.'.server_name', 'Foo');
+    Date::setTestNow(Date::now()->startOfMinute());
+
+    Servers::detectCpuUsing(fn () => 987654321);
+    Servers::detectMemoryUsing(fn () => [
+        'total' => 123456789,
+        'used' => 1234,
+    ]);
+    event(new SharedBeat(CarbonImmutable::now(), 'instance-id'));
+    Pulse::ingest();
+
+    $value = Pulse::ignore(fn () => DB::table('pulse_values')->sole());
+
+    $payload = json_decode($value->value);
+    expect($payload->cpu)->toBe(987654321);
+    expect($payload->memory_used)->toBe(1234);
+    expect($payload->memory_total)->toBe(123456789);
+
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->get());
+    expect($aggregates->count())->toBe(8);
+    expect($aggregates->pluck('type')->unique()->values()->all())->toBe(['cpu', 'memory']);
+    expect($aggregates->pluck('value')->unique()->values()->all())->toBe(['987654321.00', '1234.00']);
+
+    Servers::detectCpuUsing(null);
+    Servers::detectMemoryUsing(null);
+});

--- a/tests/Feature/Recorders/ServersTest.php
+++ b/tests/Feature/Recorders/ServersTest.php
@@ -57,7 +57,7 @@ it('can customise CPU and memory resolution', function () {
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->get());
     expect($aggregates->count())->toBe(8);
     expect($aggregates->pluck('type')->unique()->values()->all())->toBe(['cpu', 'memory']);
-    expect($aggregates->pluck('value')->unique()->values()->all())->toBe(['987654321.00', '1234.00']);
+    expect($aggregates->pluck('value')->unique()->values()->all())->toEqual(['987654321.00', '1234.00']);
 
     Servers::detectCpuUsing(null);
     Servers::detectMemoryUsing(null);


### PR DESCRIPTION
fixes https://github.com/laravel/pulse/issues/322

Allows the server stat collection to be customised.

In a service provider it is now easy to customise the CPU and memory stat collection depending on your special operating system or unique infrastructure (docker, et al.).

```php
Servers::detectCpuUsing(function (): int {
    // ...
});

Servers::detectMemoryUsing(fn () => [
    'total' => (int) /* ... */,
    'used' => (int) /* ... */,
]);
```