### PR TITLE
Bump livewire to fix CVE-2024-21504

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "illuminate/routing": "^10.48.4|^11.0.8",
         "illuminate/support": "^10.48.4|^11.0.8",
         "illuminate/view": "^10.48.4|^11.0.8",
-        "livewire/livewire": "^3.2",
+        "livewire/livewire": "^3.4.9",
         "symfony/console": "^6.0|^7.0",
         "nesbot/carbon": "^2.67|^3.0"
     },


### PR DESCRIPTION
Bump livewire version >=3.4.9 to fix https://github.com/advisories/GHSA-389c-cf87-qmwj
