### PR TITLE
Implement Tagging for Recorders in Pulse

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -147,6 +147,7 @@ return [
 
         Recorders\Exceptions::class => [
             'enabled' => env('PULSE_EXCEPTIONS_ENABLED', true),
+            'tags_enabled' => env('PULSE_EXCEPTIONS_TAGS_ENABLED', true),
             'sample_rate' => env('PULSE_EXCEPTIONS_SAMPLE_RATE', 1),
             'location' => env('PULSE_EXCEPTIONS_LOCATION', true),
             'ignore' => [

--- a/resources/views/livewire/exceptions.blade.php
+++ b/resources/views/livewire/exceptions.blade.php
@@ -49,6 +49,16 @@
                                     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate" title="{{ $exception->location }}">
                                         {{ $exception->location }}
                                     </p>
+                                    @if ($exception->tags)
+                                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate">
+                                            Tags:
+                                            @foreach ($exception->tags as $tag)
+                                                <span class="inline-block px-1 text-xs text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 rounded-full mt-1 mr-1">
+                                                {{ $tag }}
+                                                </span>
+                                            @endforeach
+                                        </p>
+                                    @endif
                                 </x-pulse::td>
                                 <x-pulse::td numeric class="text-gray-700 dark:text-gray-300 font-bold">
                                     {{ $exception->latest->ago(syntax: Carbon\CarbonInterface::DIFF_ABSOLUTE, short: true) }}

--- a/src/Facades/Pulse.php
+++ b/src/Facades/Pulse.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static mixed ignore(callable $callback)
  * @method static \Laravel\Pulse\Pulse flush()
  * @method static \Laravel\Pulse\Pulse filter(callable $filter)
+ * @method static \Laravel\Pulse\Pulse tag(callable $tag)
  * @method static int ingest()
  * @method static int digest()
  * @method static bool wantsIngesting()

--- a/src/Livewire/Exceptions.php
+++ b/src/Livewire/Exceptions.php
@@ -29,6 +29,8 @@ class Exceptions extends Card
      */
     public function render(): Renderable
     {
+        $isTagsEnabled = Config::get('pulse.recorders.'.ExceptionsRecorder::class.'.tags_enabled');
+
         [$exceptions, $time, $runAt] = $this->remember(
             fn () => $this->aggregate(
                 'exception',
@@ -37,12 +39,12 @@ class Exceptions extends Card
                     'latest' => 'max',
                     default => 'count'
                 },
-            )->map(function ($row) {
-                [$class, $location] = json_decode($row->key, flags: JSON_THROW_ON_ERROR);
-
+            )->map(function ($row) use ($isTagsEnabled) {
+                $keys = json_decode(json: $row->key,associative: true, flags: JSON_THROW_ON_ERROR);
                 return (object) [
-                    'class' => $class,
-                    'location' => $location,
+                    'class' => $keys[0],
+                    'location' => $keys[1],
+                    'tags' => $isTagsEnabled ? ($keys[2] ?? null) : null,
                     'latest' => CarbonImmutable::createFromTimestamp($row->max),
                     'count' => $row->count,
                 ];

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -63,6 +63,13 @@ class Pulse
     protected Collection $filters;
 
     /**
+     * The list of tags.
+     *
+     * @var \Illuminate\Support\Collection<int, callable(): string>
+     */
+    protected Collection $tags;
+
+    /**
      * The remembered user's ID.
      */
     protected int|string|null $rememberedUserId = null;
@@ -97,6 +104,7 @@ class Pulse
     public function __construct(protected Application $app)
     {
         $this->filters = collect([]);
+        $this->tags = collect([]);
         $this->recorders = collect([]);
         $this->entries = collect([]);
         $this->lazy = collect([]);
@@ -281,6 +289,26 @@ class Pulse
         $this->filters[] = $filter;
 
         return $this;
+    }
+
+    /**
+     * Tag the items.
+     *
+     * @param callable(): string $tag
+     */
+    public function tag(callable $tag): self
+    {
+        $this->tags[] = $tag;
+
+        return $this;
+    }
+
+    /**
+     * Resolve the tags for the given entry.
+     */
+    public function resolveTags(): array
+    {
+        return $this->tags->map(fn ($tag) => $tag())->all();
     }
 
     /**

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -305,6 +305,8 @@ class Pulse
 
     /**
      * Resolve the tags for the given entry.
+     *
+     * @return array<string>
      */
     public function resolveTags(): array
     {

--- a/src/Recorders/Exceptions.php
+++ b/src/Recorders/Exceptions.php
@@ -58,11 +58,16 @@ class Exceptions
                 ? $this->resolveLocation($e)
                 : null;
 
+            $key = [$class, $location];
+            if ($this->config->get('pulse.recorders.' . self::class . '.tags_enabled')) {
+                $key[] = $this->pulse->resolveTags();
+            }
+
             $this->pulse->record(
                 type: 'exception',
-                key: json_encode([$class, $location], flags: JSON_THROW_ON_ERROR),
-                timestamp: $timestamp,
+                key: json_encode($key, flags: JSON_THROW_ON_ERROR),
                 value: $timestamp,
+                timestamp: $timestamp,
             )->max()->count();
         });
     }

--- a/tests/Feature/Livewire/ExceptionsTest.php
+++ b/tests/Feature/Livewire/ExceptionsTest.php
@@ -36,7 +36,37 @@ it('renders exceptions', function () {
 
     Livewire::test(Exceptions::class, ['lazy' => false])
         ->assertViewHas('exceptions', collect([
-            (object) ['class' => 'RuntimeException', 'location' => 'app/Foo.php:123', 'count' => 4, 'latest' => now()],
-            (object) ['class' => 'RuntimeException', 'location' => 'app/Bar.php:123', 'count' => 2, 'latest' => now()],
+            (object) ['class' => 'RuntimeException', 'location' => 'app/Foo.php:123', 'count' => 4, 'latest' => now(), 'tags' => null],
+            (object) ['class' => 'RuntimeException', 'location' => 'app/Bar.php:123', 'count' => 2, 'latest' => now(), 'tags' => null],
+        ]));
+});
+
+it('renders exceptions with tags', function () {
+    $exception1 = json_encode(['RuntimeException', 'app/Foo.php:123', ['tag1', 'tag2']]);
+    $exception2 = json_encode(['RuntimeException', 'app/Bar.php:123', ['tag1', 'tag2']]);
+
+    // Add entries outside of the window.
+    Carbon::setTestNow('2000-01-01 12:00:00');
+    Pulse::record('exception', $exception1, now()->timestamp)->max()->count();
+    Pulse::record('exception', $exception2, now()->timestamp)->max()->count();
+
+    // Add entries to the "tail".
+    Carbon::setTestNow('2000-01-01 12:00:01');
+    Pulse::record('exception', $exception1, now()->timestamp)->max()->count();
+    Pulse::record('exception', $exception1, now()->timestamp)->max()->count();
+    Pulse::record('exception', $exception2, now()->timestamp)->max()->count();
+
+    // Add entries to the current buckets.
+    Carbon::setTestNow('2000-01-01 13:00:00');
+    Pulse::record('exception', $exception1, now()->timestamp)->max()->count();
+    Pulse::record('exception', $exception1, now()->timestamp)->max()->count();
+    Pulse::record('exception', $exception2, now()->timestamp)->max()->count();
+
+    Pulse::ingest();
+
+    Livewire::test(Exceptions::class, ['lazy' => false])
+        ->assertViewHas('exceptions', collect([
+            (object) ['class' => 'RuntimeException', 'location' => 'app/Foo.php:123', 'count' => 4, 'latest' => now(), 'tags' => ['tag1', 'tag2']],
+            (object) ['class' => 'RuntimeException', 'location' => 'app/Bar.php:123', 'count' => 2, 'latest' => now(), 'tags' => ['tag1', 'tag2']],
         ]));
 });

--- a/tests/Feature/Recorders/ExceptionsTest.php
+++ b/tests/Feature/Recorders/ExceptionsTest.php
@@ -61,7 +61,7 @@ it('can disable capturing the location', function () {
         'value' => now()->timestamp,
     ]);
     $key = json_decode($entries[0]->key);
-    expect($key)->toBe(['RuntimeException', null]);
+    expect($key)->toBe(['RuntimeException', null, []]);
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->get());
     expect($aggregates)->toHaveCount(8);
     expect($aggregates[0])->toHaveProperties([
@@ -72,7 +72,7 @@ it('can disable capturing the location', function () {
         'value' => 1,
     ]);
     $key = json_decode($aggregates[0]->key);
-    expect($key)->toBe(['RuntimeException', null]);
+    expect($key)->toBe(['RuntimeException', null, []]);
     expect($aggregates[1])->toHaveProperties([
         'bucket' => (int) (floor(now()->timestamp / 60) * 60),
         'period' => 60,
@@ -81,7 +81,7 @@ it('can disable capturing the location', function () {
         'value' => now()->timestamp,
     ]);
     $key = json_decode($aggregates[1]->key);
-    expect($key)->toBe(['RuntimeException', null]);
+    expect($key)->toBe(['RuntimeException', null, []]);
 });
 
 it('can manually report exceptions', function () {
@@ -161,6 +161,27 @@ it('can sample at one', function () {
     report(new MyReportedException());
 
     expect(Pulse::ingest())->toBe(10);
+});
+
+it('can tag exceptions', function () {
+    Pulse::tag(fn () => 'tag1');
+    Pulse::tag(fn () => 'tag2');
+
+    report(new MyReportedException('Hello, Pulse!'));
+    Pulse::ingest();
+
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
+    $key = json_decode($entries[0]->key);
+
+    expect($entries)->toHaveCount(1);
+    expect($entries[0])->toHaveProperties([
+        'timestamp' => now()->timestamp,
+        'type' => 'exception',
+        'value' => now()->timestamp,
+    ]);
+    expect($key[0])->toBe('MyReportedException');
+    expect($key[1])->toStartWith(__FILE__ . ':');
+    expect($key[2])->toBe(["tag1", "tag2"]);
 });
 
 class MyReportedException extends Exception

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;


### PR DESCRIPTION
This pull request introduces a new feature to the Pulse package that allows developers to tag all types of records. This feature enhances the tracking capabilities of Pulse, providing more context and granularity when analysing records.

The implementation involves the addition of a `tag` method to the Pulse facade, which accepts a callback function. The callback function is expected to return a string that represents the tag. These tags are then included in the record data that Pulse records.

This feature does not break any existing features of the Pulse package. It is an optional enhancement that developers can choose to use if they find it beneficial.

The benefit to end users is the ability to categorise and filter records based on custom criteria. For example, a developer could tag records that occur within a specific module of their application, making it easier to identify patterns or recurring issues within that module.

Tests have been added to ensure the correct functioning of this feature. The tests cover the basic usage of the `tag` method, as well as more complex scenarios involving multiple tags and records.

This feature makes building web applications easier by providing developers with more control and flexibility when it comes to tracking. It allows developers to tailor the tracking capabilities of Pulse to better suit their specific needs and the needs of their application.

This is an initial implementation for tagging all types of records. If this approach is deemed beneficial, I plan to extend this functionality to include tags for the rest of the recorders in the Pulse package.

Thank you for considering this contribution. I look forward to your feedback.