### PR TITLE
Add support for Relay

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip
+          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip, relay
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
@@ -105,7 +105,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip
+          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip, relay
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
@@ -161,7 +161,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip
+          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip, relay
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
@@ -209,7 +209,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip
+          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip, relay
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "nesbot/carbon": "^2.67|^3.0"
     },
     "require-dev": {
+        "cachewerk/relay": "^0.7.0",
         "guzzlehttp/guzzle": "^7.7",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^8.23.1|^9.0",

--- a/src/Support/RedisAdapter.php
+++ b/src/Support/RedisAdapter.php
@@ -134,7 +134,7 @@ class RedisAdapter
             $this->client() instanceof PhpRedis => $this->client()->rawCommand(...$args),
             $this->client() instanceof Relay => $this->client()->rawCommand(...$args),
             $this->client() instanceof Predis,
-                $this->client() instanceof Pipeline => $this->client()->executeCommand(RawCommand::create(...$args)),
+            $this->client() instanceof Pipeline => $this->client()->executeCommand(RawCommand::create(...$args)),
         };
     }
 

--- a/src/Support/RedisAdapter.php
+++ b/src/Support/RedisAdapter.php
@@ -10,6 +10,7 @@ use Predis\Command\RawCommand;
 use Predis\Pipeline\Pipeline;
 use Predis\Response\ServerException as PredisServerException;
 use Redis as PhpRedis;
+use Relay\Relay;
 
 /**
  * @internal
@@ -22,7 +23,7 @@ class RedisAdapter
     public function __construct(
         protected Connection $connection,
         protected Repository $config,
-        protected Pipeline|PhpRedis|null $client = null,
+        protected Pipeline|PhpRedis|Relay|null $client = null,
     ) {
         //
     }
@@ -32,7 +33,7 @@ class RedisAdapter
      *
      * @param  array<string, string>  $dictionary
      */
-    public function xadd(string $key, array $dictionary): string|Pipeline|PhpRedis
+    public function xadd(string $key, array $dictionary): string|Pipeline|PhpRedis|Relay
     {
         return $this->handle([
             'XADD',
@@ -57,7 +58,7 @@ class RedisAdapter
             ...$count !== null ? ['COUNT', "$count"] : [],
         ]))->mapWithKeys(fn ($value, $key) => [
             $value[0] => collect($value[1]) // @phpstan-ignore argument.templateType argument.templateType
-                ->chunk(2)
+            ->chunk(2)
                 ->map->values()
                 ->mapWithKeys(fn ($value, $key) => [$value[0] => $value[1]])
                 ->all(),
@@ -101,7 +102,7 @@ class RedisAdapter
     public function pipeline(callable $closure): array
     {
         // Create a pipeline and wrap the Redis client in an instance of this class to ensure our wrapper methods are used within the pipeline...
-        return $this->connection->pipeline(fn (Pipeline|PhpRedis $client) => $closure(new self($this->connection, $this->config, $client))); // @phpstan-ignore method.notFound
+        return $this->connection->pipeline(fn (Pipeline|PhpRedis|Relay $client) => $closure(new self($this->connection, $this->config, $client))); // @phpstan-ignore method.notFound
     }
 
     /**
@@ -113,7 +114,7 @@ class RedisAdapter
     {
         try {
             return tap($this->run($args), function ($result) use ($args) {
-                if ($result === false && $this->client() instanceof PhpRedis) {
+                if ($result === false && ($this->client() instanceof PhpRedis || $this->client() instanceof Relay)) {
                     throw RedisServerException::whileRunningCommand(implode(' ', $args), $this->client()->getLastError() ?? 'An unknown error occurred.');
                 }
             });
@@ -131,15 +132,16 @@ class RedisAdapter
     {
         return match (true) {
             $this->client() instanceof PhpRedis => $this->client()->rawCommand(...$args),
+            $this->client() instanceof Relay => $this->client()->rawCommand(...$args),
             $this->client() instanceof Predis,
-            $this->client() instanceof Pipeline => $this->client()->executeCommand(RawCommand::create(...$args)),
+                $this->client() instanceof Pipeline => $this->client()->executeCommand(RawCommand::create(...$args)),
         };
     }
 
     /**
      * Retrieve the Redis client.
      */
-    protected function client(): PhpRedis|Predis|Pipeline
+    protected function client(): PhpRedis|Predis|Pipeline|Relay
     {
         return $this->client ?? $this->connection->client();
     }

--- a/tests/Feature/RedisTest.php
+++ b/tests/Feature/RedisTest.php
@@ -30,7 +30,7 @@ it('runs the same commands while ingesting entries', function ($driver) {
     ])));
 
     expect($commands)->toContain('"XADD" "laravel_database_laravel:pulse:ingest" "*" "data" "O:19:\"Laravel\\\\Pulse\\\\Entry\\":6:{s:15:\"\x00*\x00aggregations\";a:0:{}s:14:\"\x00*\x00onlyBuckets\";b:0;s:9:\"timestamp\";i:1700752211;s:4:\"type\";s:3:\"foo\";s:3:\"key\";s:3:\"bar\";s:5:\"value\";i:123;}"');
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('keeps 7 days of data, by default, when trimming', function ($driver) {
     Config::set('database.redis.client', $driver);
@@ -39,7 +39,7 @@ it('keeps 7 days of data, by default, when trimming', function ($driver) {
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
 
     expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MINID" "~" "946177445000"');
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('can configure days of data to keep when trimming', function ($driver) {
     Config::set('database.redis.client', $driver);
@@ -49,7 +49,7 @@ it('can configure days of data to keep when trimming', function ($driver) {
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
 
     expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MINID" "~" "946695845000"');
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('can configure the number of entries to keep when trimming', function ($driver) {
     Config::set('database.redis.client', $driver);
@@ -59,7 +59,7 @@ it('can configure the number of entries to keep when trimming', function ($drive
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
 
     expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MAXLEN" "~" "54321"');
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('runs the same commands while storing', function ($driver) {
     Config::set('database.redis.client', $driver);
@@ -80,7 +80,7 @@ it('runs the same commands while storing', function ($driver) {
 
     expect($commands)->toContain('"XRANGE" "laravel_database_laravel:pulse:ingest" "-" "+" "COUNT" "567"');
     expect($commands)->toContain('"XDEL" "laravel_database_laravel:pulse:ingest" "'.$firstEntryKey.'" "'.$lastEntryKey.'"');
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('has consistent return for xadd', function ($driver) {
     Config::set('database.redis.client', $driver);
@@ -96,7 +96,7 @@ it('has consistent return for xadd', function ($driver) {
     expect($parts)->toHaveCount(2);
     expect($parts[0])->toEqualWithDelta(now()->getTimestampMs(), 50);
     expect($parts[1])->toBe('0');
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('has consistent return for xrange', function ($driver) {
     Config::set('database.redis.client', $driver);
@@ -125,7 +125,7 @@ it('has consistent return for xrange', function ($driver) {
         expect($parts[1])->toBeIn(['0', '1']);
         expect($value)->toBe(array_shift($values));
     }
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('has consistent return for xtrim', function ($driver) {
     Config::set('database.redis.client', $driver);
@@ -150,14 +150,14 @@ it('has consistent return for xtrim', function ($driver) {
     $result = $redis->xtrim('stream-name', 'MINID', '=', Str::before($lastKey, '-'));
 
     expect($result)->toBe(2);
-})->with(['predis', 'phpredis']);
+})->with(['predis', 'phpredis', 'relay']);
 
 it('throws exception on failure', function ($driver) {
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
 
     $redis->xtrim('stream-name', 'FOO', 'a', 'xyz');
-})->with(['predis', 'phpredis'])->throws(RedisServerException::class, 'The Redis version does not support the command or some of its arguments [XTRIM laravel_database_stream-name FOO a xyz]. Redis error: [ERR syntax error].');
+})->with(['predis', 'phpredis', 'relay'])->throws(RedisServerException::class, 'The Redis version does not support the command or some of its arguments [XTRIM laravel_database_stream-name FOO a xyz]. Redis error: [ERR syntax error].');
 
 it('prepends the error message with the run command', function () {
     throw RedisServerException::whileRunningCommand('FOO BAR', 'Something happened');


### PR DESCRIPTION
This adds support for [Relay](https://relay.so/) to the Redis adapter, Relay is a drop-in replacement for Phpredis but up to twice as fast even without enabling the caching mechanisms.

We're using Relay in production and we'd really like to use Pulse.