### PR TITLE
[1.x] Rename highlighting prop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest -vvv
         env:
           DB_CONNECTION: mysql
           DB_DATABASE: pulse
@@ -118,7 +118,7 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest -vvv
         env:
           DB_CONNECTION: mariadb
           DB_DATABASE: pulse
@@ -175,7 +175,7 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest -vvv
         env:
           DB_CONNECTION: pgsql
           DB_DATABASE: pulse
@@ -222,6 +222,6 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest -vvv
         env:
           DB_CONNECTION: sqlite

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/sql-formatter": "^1.1",
+        "doctrine/sql-formatter": "^1.2",
         "guzzlehttp/promises": "^1.0|^2.0",
         "illuminate/auth": "^10.48.4|^11.0.8",
         "illuminate/cache": "^10.48.4|^11.0.8",

--- a/resources/views/livewire/slow-queries.blade.php
+++ b/resources/views/livewire/slow-queries.blade.php
@@ -2,7 +2,7 @@
 use \Doctrine\SqlFormatter\HtmlHighlighter;
 use \Doctrine\SqlFormatter\SqlFormatter;
 
-if (! $this->disableHighlighting) {
+if ($this->wantsHighlighting()) {
     $sqlFormatter = new SqlFormatter(new HtmlHighlighter([
         HtmlHighlighter::HIGHLIGHT_RESERVED => 'class="font-semibold"',
         HtmlHighlighter::HIGHLIGHT_QUOTE => 'class="text-purple-200"',
@@ -62,7 +62,7 @@ if (! $this->disableHighlighting) {
                             <x-pulse::td class="!p-0 truncate max-w-[1px]">
                                 <div class="relative">
                                     <div class="bg-gray-700 dark:bg-gray-800 py-4 rounded-md text-gray-100 block text-xs whitespace-nowrap overflow-x-auto [scrollbar-color:theme(colors.gray.500)_transparent] [scrollbar-width:thin]">
-                                        <code class="px-3">{!! $this->disableHighlighting ? $query->sql : $sqlFormatter->highlight($query->sql) !!}</code>
+                                        <code class="px-3">{!! $this->wantsHighlighting() ? $sqlFormatter->highlight($query->sql) : $query->sql  !!}</code>
                                         @if ($query->location)
                                             <p class="px-3 mt-3 text-xs leading-none text-gray-400 dark:text-gray-500">
                                                 {{ $query->location }}

--- a/src/Livewire/SlowQueries.php
+++ b/src/Livewire/SlowQueries.php
@@ -26,6 +26,13 @@ class SlowQueries extends Card
     /**
      * Indicates that SQL highlighting should be disabled.
      */
+    public bool $withoutHighlighting = false;
+
+    /**
+     * Indicates that SQL highlighting should be disabled.
+     *
+     * @deprecated
+     */
     public bool $disableHighlighting = false;
 
     /**
@@ -60,5 +67,13 @@ class SlowQueries extends Card
             'config' => Config::get('pulse.recorders.'.SlowQueriesRecorder::class),
             'slowQueries' => $slowQueries,
         ]);
+    }
+
+    /**
+     * Determine if the view should highlight SQL queries.
+     */
+    protected function wantsHighlighting(): bool
+    {
+        return ! ($this->withoutHighlighting || $this->disableHighlighting);
     }
 }

--- a/tests/Feature/Livewire/SlowQueriesTest.php
+++ b/tests/Feature/Livewire/SlowQueriesTest.php
@@ -40,3 +40,45 @@ it('renders slow queries', function () {
             (object) ['sql' => 'select * from `users` where `id` = ?', 'location' => 'app/Bar.php:456', 'count' => 2, 'slowest' => 1234],
         ]));
 });
+
+it('highlights SQL queries', function () {
+    $query = json_encode(['select * from `users`', 'app/Foo.php:123']);
+
+    Carbon::setTestNow('2000-01-01 13:00:00');
+    Pulse::record('slow_query', $query, 1000)->max()->count();
+
+    Pulse::ingest();
+
+    Livewire::test(SlowQueries::class, ['lazy' => false])
+        ->assertSeeHtml(<<<'HTML'
+            <code class="px-3"><span class="font-semibold">SELECT</span> <span class="text-cyan-200">*</span> <span class="font-semibold">FROM</span> <span class="text-purple-200">`users`</span></code>
+            HTML);
+});
+
+it('can opt out of syntax highlighting', function () {
+    $query = json_encode(['select * from `users`', 'app/Foo.php:123']);
+
+    Carbon::setTestNow('2000-01-01 13:00:00');
+    Pulse::record('slow_query', $query, 1000)->max()->count();
+
+    Pulse::ingest();
+
+    Livewire::test(SlowQueries::class, ['lazy' => false, 'withoutHighlighting' => true])
+        ->assertSeeHtml(<<<'HTML'
+            <code class="px-3">select * from `users`</code>
+            HTML);
+});
+
+it('can opt out of syntax highlighting with deprecated property', function () {
+    $query = json_encode(['select * from `users`', 'app/Foo.php:123']);
+
+    Carbon::setTestNow('2000-01-01 13:00:00');
+    Pulse::record('slow_query', $query, 1000)->max()->count();
+
+    Pulse::ingest();
+
+    Livewire::test(SlowQueries::class, ['lazy' => false, 'disableHighlighting' => true])
+        ->assertSeeHtml(<<<'HTML'
+            <code class="px-3">select * from `users`</code>
+            HTML);
+});

--- a/tests/Feature/Livewire/SlowQueriesTest.php
+++ b/tests/Feature/Livewire/SlowQueriesTest.php
@@ -42,11 +42,10 @@ it('renders slow queries', function () {
 });
 
 it('highlights SQL queries', function () {
+    Carbon::setTestNow('2000-01-01 13:00:00');
     $query = json_encode(['select * from `users`', 'app/Foo.php:123']);
 
-    Carbon::setTestNow('2000-01-01 13:00:00');
     Pulse::record('slow_query', $query, 1000)->max()->count();
-
     Pulse::ingest();
 
     Livewire::test(SlowQueries::class, ['lazy' => false])
@@ -56,11 +55,10 @@ it('highlights SQL queries', function () {
 });
 
 it('can opt out of syntax highlighting', function () {
+    Carbon::setTestNow('2000-01-01 13:00:00');
     $query = json_encode(['select * from `users`', 'app/Foo.php:123']);
 
-    Carbon::setTestNow('2000-01-01 13:00:00');
     Pulse::record('slow_query', $query, 1000)->max()->count();
-
     Pulse::ingest();
 
     Livewire::test(SlowQueries::class, ['lazy' => false, 'withoutHighlighting' => true])
@@ -70,11 +68,10 @@ it('can opt out of syntax highlighting', function () {
 });
 
 it('can opt out of syntax highlighting with deprecated property', function () {
+    Carbon::setTestNow('2000-01-01 13:00:00');
     $query = json_encode(['select * from `users`', 'app/Foo.php:123']);
 
-    Carbon::setTestNow('2000-01-01 13:00:00');
     Pulse::record('slow_query', $query, 1000)->max()->count();
-
     Pulse::ingest();
 
     Livewire::test(SlowQueries::class, ['lazy' => false, 'disableHighlighting' => true])


### PR DESCRIPTION
```blade
<livewire:pulse.slow-queries without-highlighting />

<!-- Supported but deprecated -->
<livewire:pulse.slow-queries disable-highlighting />
```

Docs: https://github.com/laravel/docs/pull/9635