### PR TITLE
[1.x] Cache testing improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+           composer require cachewerk/relay --no-interaction --no-update
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
@@ -115,6 +116,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+           composer require cachewerk/relay --no-interaction --no-update
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
@@ -172,6 +174,7 @@ jobs:
       - name: Install dependencies
         run: |
            composer require "illuminate/contracts=^${{ matrix.laravel }}" --dev --no-update
+           composer require cachewerk/relay --no-interaction --no-update
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
@@ -219,6 +222,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+           composer require cachewerk/relay --no-interaction --no-update
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "nesbot/carbon": "^2.67|^3.0"
     },
     "require-dev": {
-        "cachewerk/relay": "^0.7.0",
         "guzzlehttp/guzzle": "^7.7",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^8.23.1|^9.0",

--- a/tests/Feature/RedisTest.php
+++ b/tests/Feature/RedisTest.php
@@ -14,6 +14,22 @@ use Laravel\Pulse\Support\RedisAdapter;
 use Laravel\Pulse\Support\RedisServerException;
 use Tests\StorageFake;
 
+$drivers = ['predis', 'phpredis', 'relay'];
+
+function skipWhenExtensionMissing($driver) {
+    $extension = match ($driver) {
+        'phpredis' => 'redis',
+        default => $driver,
+    };
+
+    match ($extension) {
+        'predis' => null,
+        'redis', 'relay' => ! extension_loaded($extension)
+            ? test()->markTestSkipped("PHP extension [{$extension}] missing for Redis driver [{$driver}].")
+            : null,
+    };
+}
+
 beforeEach(function () {
     try {
         Process::timeout(1)->run('redis-cli -p '.Config::get('database.redis.default.port').' FLUSHALL')->throw();
@@ -23,6 +39,8 @@ beforeEach(function () {
 });
 
 it('runs the same commands while ingesting entries', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
 
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->ingest(collect([
@@ -30,18 +48,22 @@ it('runs the same commands while ingesting entries', function ($driver) {
     ])));
 
     expect($commands)->toContain('"XADD" "laravel_database_laravel:pulse:ingest" "*" "data" "O:19:\"Laravel\\\\Pulse\\\\Entry\\":6:{s:15:\"\x00*\x00aggregations\";a:0:{}s:14:\"\x00*\x00onlyBuckets\";b:0;s:9:\"timestamp\";i:1700752211;s:4:\"type\";s:3:\"foo\";s:3:\"key\";s:3:\"bar\";s:5:\"value\";i:123;}"');
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('keeps 7 days of data, by default, when trimming', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
 
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
 
     expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MINID" "~" "946177445000"');
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('can configure days of data to keep when trimming', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
     Config::set('pulse.ingest.trim.keep', '1 day');
@@ -49,9 +71,11 @@ it('can configure days of data to keep when trimming', function ($driver) {
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
 
     expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MINID" "~" "946695845000"');
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('can configure the number of entries to keep when trimming', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
     Config::set('pulse.ingest.trim.keep', 54321);
@@ -59,9 +83,11 @@ it('can configure the number of entries to keep when trimming', function ($drive
     $commands = captureRedisCommands(fn () => App::make(RedisIngest::class)->trim());
 
     expect($commands)->toContain('"XTRIM" "laravel_database_laravel:pulse:ingest" "MAXLEN" "~" "54321"');
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('runs the same commands while storing', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     Config::set('pulse.ingest.redis.chunk', 567);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
@@ -80,9 +106,11 @@ it('runs the same commands while storing', function ($driver) {
 
     expect($commands)->toContain('"XRANGE" "laravel_database_laravel:pulse:ingest" "-" "+" "COUNT" "567"');
     expect($commands)->toContain('"XDEL" "laravel_database_laravel:pulse:ingest" "'.$firstEntryKey.'" "'.$lastEntryKey.'"');
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('has consistent return for xadd', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
 
@@ -96,9 +124,11 @@ it('has consistent return for xadd', function ($driver) {
     expect($parts)->toHaveCount(2);
     expect($parts[0])->toEqualWithDelta(now()->getTimestampMs(), 50);
     expect($parts[1])->toBe('0');
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('has consistent return for xrange', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
     $redis->xadd('stream-name', [
@@ -125,9 +155,11 @@ it('has consistent return for xrange', function ($driver) {
         expect($parts[1])->toBeIn(['0', '1']);
         expect($value)->toBe(array_shift($values));
     }
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('has consistent return for xtrim', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
 
@@ -150,14 +182,16 @@ it('has consistent return for xtrim', function ($driver) {
     $result = $redis->xtrim('stream-name', 'MINID', '=', Str::before($lastKey, '-'));
 
     expect($result)->toBe(2);
-})->with(['predis', 'phpredis', 'relay']);
+})->with($drivers);
 
 it('throws exception on failure', function ($driver) {
+    skipWhenExtensionMissing($driver);
+
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
 
     $redis->xtrim('stream-name', 'FOO', 'a', 'xyz');
-})->with(['predis', 'phpredis', 'relay'])->throws(RedisServerException::class, 'The Redis version does not support the command or some of its arguments [XTRIM laravel_database_stream-name FOO a xyz]. Redis error: [ERR syntax error].');
+})->with($drivers)->throws(RedisServerException::class, 'The Redis version does not support the command or some of its arguments [XTRIM laravel_database_stream-name FOO a xyz]. Redis error: [ERR syntax error].');
 
 it('prepends the error message with the run command', function () {
     throw RedisServerException::whileRunningCommand('FOO BAR', 'Something happened');

--- a/tests/Feature/RedisTest.php
+++ b/tests/Feature/RedisTest.php
@@ -16,7 +16,8 @@ use Tests\StorageFake;
 
 $drivers = ['predis', 'phpredis', 'relay'];
 
-function skipWhenExtensionMissing($driver) {
+function skipWhenExtensionMissing($driver)
+{
     $extension = match ($driver) {
         'phpredis' => 'redis',
         default => $driver,


### PR DESCRIPTION
This PR allows the `composer install` and running the testsuite without requiring `phpredis` and `relay` PHP extensions to be installed.

`predis` will always be installed for local testing and CI will always have `predis`, `phpredis`, and `relay` installed.

If you have the extensions installed locally the tests will run against the drivers.