### PR TITLE
[1.x] Ensure missing user does not throw a type error

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -119,6 +119,10 @@ class PulseServiceProvider extends ServiceProvider
         $this->app->booted(function () {
             $this->callAfterResolving(Dispatcher::class, function (Dispatcher $event, Application $app) {
                 $event->listen(function (Logout $event) use ($app) {
+                    if ($event->user === null) {
+                        return;
+                    }
+
                     $pulse = $app->make(Pulse::class);
 
                     $pulse->rescue(fn () => $pulse->rememberUser($event->user));

--- a/tests/Feature/PulseTest.php
+++ b/tests/Feature/PulseTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Illuminate\Auth\Events\Logout;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
 use Laravel\Pulse\Contracts\ResolvesUsers;
 use Laravel\Pulse\Contracts\Storage;
@@ -244,6 +246,13 @@ it('strips arguments from persistent middleware', function () {
 
     expect($persistentMiddleware)->toContain(MyTestMiddleware::class);
     expect($persistentMiddleware)->not->toContain(MyTestMiddleware::class.':admin');
+});
+
+it('handles logout events when there is no user', function () {
+    // This will throw a type error when unhandled...
+    Event::dispatch(new Logout('session', user: null));
+
+    expect(true)->toBe(true);
 });
 
 class MyTestMiddleware


### PR DESCRIPTION
Fixes https://github.com/laravel/pulse/issues/364, https://github.com/laravel/pulse/issues/324

Due to what is described in https://github.com/laravel/fortify/pull/536, Pulse will throw a type error if a `null` user is attached to the `Logout` event.

Although we are fixing this across the ecosystem, we should fix this for users that have not updated the packages or are using `laravel/ui`, which does not get a backwards fix, i.e., only new laravel/ui usages get the fix.