### PR TITLE
[1.x] Improve config for 3rd party cards

### DIFF
--- a/src/Recorders/CacheInteractions.php
+++ b/src/Recorders/CacheInteractions.php
@@ -5,7 +5,6 @@ namespace Laravel\Pulse\Recorders;
 use Carbon\CarbonImmutable;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
-use Illuminate\Config\Repository;
 use Laravel\Pulse\Pulse;
 
 /**
@@ -30,7 +29,6 @@ class CacheInteractions
      */
     public function __construct(
         protected Pulse $pulse,
-        protected Repository $config,
     ) {
         //
     }

--- a/src/Recorders/Concerns/Groups.php
+++ b/src/Recorders/Concerns/Groups.php
@@ -9,7 +9,7 @@ trait Groups
      */
     protected function group(string $value): string
     {
-        foreach ($this->config->get('pulse.recorders.'.static::class.'.groups') as $pattern => $replacement) {
+        foreach ($this->config->get('pulse.recorders.'.static::class.'.groups', []) as $pattern => $replacement) {
             $group = preg_replace($pattern, $replacement, $value, count: $count);
 
             if ($count > 0 && $group !== null) {

--- a/src/Recorders/Concerns/Groups.php
+++ b/src/Recorders/Concerns/Groups.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Pulse\Recorders\Concerns;
 
+use Illuminate\Support\Facades\Config;
+
 trait Groups
 {
     /**
@@ -9,7 +11,7 @@ trait Groups
      */
     protected function group(string $value): string
     {
-        foreach ($this->config->get('pulse.recorders.'.static::class.'.groups', []) as $pattern => $replacement) {
+        foreach (Config::get('pulse.recorders.'.static::class.'.groups', []) as $pattern => $replacement) {
             $group = preg_replace($pattern, $replacement, $value, count: $count);
 
             if ($count > 0 && $group !== null) {

--- a/src/Recorders/Concerns/Ignores.php
+++ b/src/Recorders/Concerns/Ignores.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Pulse\Recorders\Concerns;
 
+use Illuminate\Support\Facades\Config;
+
 trait Ignores
 {
     /**
@@ -10,7 +12,7 @@ trait Ignores
     protected function shouldIgnore(string $value): bool
     {
         // @phpstan-ignore argument.templateType, argument.templateType
-        return collect($this->config->get('pulse.recorders.'.static::class.'.ignore'))
+        return collect(Config::get('pulse.recorders.'.static::class.'.ignore', []))
             ->contains(fn (string $pattern) => preg_match($pattern, $value));
     }
 }

--- a/src/Recorders/Concerns/Sampling.php
+++ b/src/Recorders/Concerns/Sampling.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Pulse\Recorders\Concerns;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Lottery;
 
 trait Sampling
@@ -12,7 +13,7 @@ trait Sampling
     protected function shouldSample(): bool
     {
         return Lottery::odds(
-            $this->config->get('pulse.recorders.'.static::class.'.sample_rate')
+            Config::get('pulse.recorders.'.static::class.'.sample_rate', 1)
         )->choose();
     }
 
@@ -23,6 +24,6 @@ trait Sampling
     {
         $value = hexdec(md5($seed)) / pow(16, 32); // Scale to 0-1
 
-        return $value <= $this->config->get('pulse.recorders.'.static::class.'.sample_rate');
+        return $value <= Config::get('pulse.recorders.'.static::class.'.sample_rate', 1);
     }
 }

--- a/src/Recorders/Concerns/Thresholds.php
+++ b/src/Recorders/Concerns/Thresholds.php
@@ -21,7 +21,7 @@ trait Thresholds
     {
         $recorder ??= static::class;
 
-        $config = Config::get("pulse.recorders.{$recorder}.threshold");
+        $config = Config::get("pulse.recorders.{$recorder}.threshold", 1_000);
 
         if (! is_array($config)) {
             return $config;

--- a/src/Recorders/SlowJobs.php
+++ b/src/Recorders/SlowJobs.php
@@ -3,7 +3,6 @@
 namespace Laravel\Pulse\Recorders;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Config\Repository;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
@@ -39,7 +38,6 @@ class SlowJobs
      */
     public function __construct(
         protected Pulse $pulse,
-        protected Repository $config,
     ) {
         //
     }

--- a/src/Recorders/SlowOutgoingRequests.php
+++ b/src/Recorders/SlowOutgoingRequests.php
@@ -4,7 +4,6 @@ namespace Laravel\Pulse\Recorders;
 
 use Carbon\CarbonImmutable;
 use GuzzleHttp\Promise\RejectedPromise;
-use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Client\Factory;
 use Laravel\Pulse\Concerns\ConfiguresAfterResolving;
@@ -29,7 +28,6 @@ class SlowOutgoingRequests
      */
     public function __construct(
         protected Pulse $pulse,
-        protected Repository $config,
     ) {
         //
     }

--- a/src/Recorders/SlowRequests.php
+++ b/src/Recorders/SlowRequests.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Pulse\Recorders;
 
-use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
@@ -28,7 +27,6 @@ class SlowRequests
      */
     public function __construct(
         protected Pulse $pulse,
-        protected Repository $config,
     ) {
         //
     }

--- a/src/Recorders/UserJobs.php
+++ b/src/Recorders/UserJobs.php
@@ -3,7 +3,6 @@
 namespace Laravel\Pulse\Recorders;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Config\Repository;
 use Illuminate\Queue\Events\JobQueued;
 use Laravel\Pulse\Pulse;
 
@@ -28,7 +27,6 @@ class UserJobs
      */
     public function __construct(
         protected Pulse $pulse,
-        protected Repository $config,
     ) {
         //
     }

--- a/src/Recorders/UserRequests.php
+++ b/src/Recorders/UserRequests.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Pulse\Recorders;
 
-use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
@@ -27,7 +26,6 @@ class UserRequests
      */
     public function __construct(
         protected Pulse $pulse,
-        protected Repository $config,
     ) {
         //
     }


### PR DESCRIPTION
This PR improves the experience for 3rd party cards that are re-using our traits / features in their own cards.

- Traits now utilise the `Config` facade so that recorders do not _need_ to inject their own config instance – making them more self contained.
- Provide defaults for the config values. This is useful if a 3rd party card introduces a feature, such as grouping, but there are apps out there that may not have the config value when they update – because they started on an earlier version.