### PR TITLE
Fix exception from missing import on select component

### DIFF
--- a/resources/views/components/pulse.blade.php
+++ b/resources/views/components/pulse.blade.php
@@ -1,6 +1,4 @@
-@php
-    use Laravel\Pulse\Facades\Pulse;
-@endphp
+@use('Laravel\Pulse\Facades\Pulse')
 @props(['cols' => 12, 'fullWidth' => false])
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">

--- a/resources/views/components/pulse.blade.php
+++ b/resources/views/components/pulse.blade.php
@@ -1,3 +1,6 @@
+@php
+    use Laravel\Pulse\Facades\Pulse;
+@endphp
 @props(['cols' => 12, 'fullWidth' => false])
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
@@ -12,10 +15,10 @@
         <link href="https://fonts.bunny.net/css?family=figtree:300,400,500,600" rel="stylesheet" />
         <link href="data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAACQFBMVEUAAAD6WlXyWmb2Wl77WlXxWmPqWmzpWmzdWnvhWnfjWnXUWojaWoDTWonMWpHLWpLAWqDCWp7CWp3DWp23Wqu7Wqe6WqisWrm2Wq2xWrPsWWalWsKsWrqkWsSGWumDWu2BWu97Wvd7WvZ6Wvh8WvZ5Wvn4Wlr4WlrxWmPyWmHyWmHwWmTpWm3qWmzqWmzpWm3gWnjhWnjgWnjRWovXWoTXWoTMWpHNWpDNWpDLWpPAWqDBWp/AWqDDWpzEWpvEWpvEWpvDWp23Wqy6Wqi6Wqi6Wqi7Wqe7Wqe6Wqe6WqiwWrWxWrOxWrSrWruxWrSyWrKxWrOwWrSlWsOnWsCnWr+mWsGnWr+oWr6oWr+nWsCaWtCaWtCaWs+aWtCdWs2fWsqeWsqeWsudWsyeWsueWsufWsmfWsqeWsucWs6aWtCaWs+aWtCZWtGUWteVWteXWtSVWtaUWteUWteVWteXWtSVWtaVWteUWteSWtqUWtiUWteUWtePWt6OWt+OWt+OWt+OWt+XWtSMWuKLWuOLWuKMWuGLWuOLWuOKWuSLWuOLWuKNWuCOWt+QWt2DWu2CWu+CWu6EWuuCWu6BWu+BWu+DWu17WvZ7Wvd7Wvd7Wvd7Wvd7Wvd8WvZ6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6Wvh6WvjhWnfXWoPNWo/EWpu7Wqe6WqexWrOnWr+oWr+eWsuUWteLWuOBWu97Wvd6Wvj///+vWn4hAAAAsHRSTlMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4NFbGpEEL28DVy/l0CpYoU0bUHM3EaNe/+2RoTwHNi0+PzOWz8sQWVj7VhI9beLsJTiI4xZWhmpsvY+Xjk6iZcuQcnaVIMt/JNk9j8xgs289wtuO9ESIeKi2ADWvyXGdjzn/jgjnEVKeZkBrP6/XEKvPA2iMgXgtIVW/74XDrVhwImyqMOGAsBFqm/VNAAAAABYktHRL/T27NVAAAAB3RJTUUH5wsQDgkSyLkAHwAAASpJREFUOMtjYBh2gJFJTZ2ZBY8CVg1NLW1WPArYdHT19Nlxy3NwGmwwNOLkwqmA29hk40ZTHl6cCvjMzDdtsrDkxyYnIGhlbSNka2e/2cFRGJsCESfnLS6irlvd3D08xbDIi0t4eW/z8fXb5h+wLVBSClOBdFDw9u0hoWE7wiO2R8rIoshFRcfExMTG7YxPSExKTklN25mekQkSAoOs7ByG3F1gkJdfsKuwqLiktKy8onIXHFRVM9TU1gFBfUNjU/Pu3S1yrW3tHZ1d3XUQUN/TC7dKvq9/z54JChMn7Zk8ZaqiHKY7laZN3ztjpqLyrL17Z89RweJTVeW5++bNV1ZesHDRYmVVbGGlvGTpsuXKyitWrlqtjDUmlJevWausrLxu/Wpl7ApGNgAAUsxoMcT6INsAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjMtMTEtMTZUMTQ6MDk6MTgrMDA6MDANsDzYAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIzLTExLTE2VDE0OjA5OjE4KzAwOjAwfO2EZAAAAFd6VFh0UmF3IHByb2ZpbGUgdHlwZSBpcHRjAAB4nOPyDAhxVigoyk/LzEnlUgADIwsuYwsTIxNLkxQDEyBEgDTDZAMjs1Qgy9jUyMTMxBzEB8uASKBKLgDqFxF08kI1lQAAAABJRU5ErkJggg==" rel="icon" type="image/x-icon">
 
-        {!! Laravel\Pulse\Facades\Pulse::css() !!}
+        {!! Pulse::css() !!}
         @livewireStyles
 
-        {!! Laravel\Pulse\Facades\Pulse::js() !!}
+        {!! Pulse::js() !!}
         @livewireScriptConfig
     </head>
     <body class="font-sans antialiased">

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,3 +1,6 @@
+@php
+    use Illuminate\Support\Str;
+@endphp
 @props([
     'id' => 'select-'.Str::random(),
     'label',

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,6 +1,4 @@
-@php
-    use Illuminate\Support\Str;
-@endphp
+@use('Illuminate\Support\Str')
 @props([
     'id' => 'select-'.Str::random(),
     'label',

--- a/resources/views/livewire/cache.blade.php
+++ b/resources/views/livewire/cache.blade.php
@@ -1,6 +1,4 @@
-@php
-    use Illuminate\Support\Str;
-@endphp
+@use('Illuminate\Support\Str')
 <x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
     <x-pulse::card-header
         name="Cache"

--- a/resources/views/livewire/queues.blade.php
+++ b/resources/views/livewire/queues.blade.php
@@ -1,6 +1,4 @@
-@php
-    use Illuminate\Support\Str;
-@endphp
+@use('Illuminate\Support\Str')
 <x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
     <x-pulse::card-header
         name="Queues"

--- a/resources/views/livewire/slow-outgoing-requests.blade.php
+++ b/resources/views/livewire/slow-outgoing-requests.blade.php
@@ -1,6 +1,4 @@
-@php
-    use Illuminate\Support\Str;
-@endphp
+@use('Illuminate\Support\Str')
 <x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
     <x-pulse::card-header
         name="Slow Outgoing Requests"

--- a/tests/Feature/PulseTest.php
+++ b/tests/Feature/PulseTest.php
@@ -13,6 +13,7 @@ use Laravel\Pulse\Contracts\Storage;
 use Laravel\Pulse\Entry;
 use Laravel\Pulse\Facades\Pulse;
 use Laravel\Pulse\Value;
+use Livewire\Livewire;
 use Livewire\LivewireManager;
 use Tests\StorageFake;
 use Tests\User;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\AliasLoader;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -19,6 +20,8 @@ abstract class TestCase extends OrchestraTestCase
         $this->usesTestingFeature(new WithMigration('laravel', 'queue'));
 
         parent::setUp();
+
+        AliasLoader::getInstance()->setAliases([]);
     }
 
     protected function defineEnvironment($app): void


### PR DESCRIPTION
Hello! I ran into this exception when upgrading to 1.2.0 today:

![image](https://github.com/laravel/pulse/assets/1533666/09031c68-e36f-4668-bc9d-857bed7f59b8)

It looks to be a missing import on the `select.blade.php` component, related to the change in #371.
This PR just adds the import in (in a similar manner to the other blade files) so that the component can use the `Str::random()` function.

This is my first contribution to the Laravel ecosystem, so please let me know if there is anything missing or things I should consider for future PRs.

Thanks for making great software!