### PR TITLE
Use contract to resolve dependency conflict in pulse:check

### DIFF
--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -5,7 +5,7 @@ namespace Laravel\Pulse\Commands;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\LockProvider;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Env;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;


### PR DESCRIPTION
This resolves the following error message when running `php artisan pulse:check` in an application that has a custom event dispatcher:

> Laravel\Pulse\Commands\CheckCommand::handle(): Argument #3 ($event) must be of type Illuminate\Events\Dispatcher, Lorisleiva\Actions\EventDispatcherDecorator given, called in /Users/joerushton/projects/newtickets/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php on line 36