### PR TITLE
[1.x] Use Contracts for common services

### DIFF
--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -5,7 +5,7 @@ namespace Laravel\Pulse\Commands;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\LockProvider;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Env;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;

--- a/src/Ingests/RedisIngest.php
+++ b/src/Ingests/RedisIngest.php
@@ -4,7 +4,7 @@ namespace Laravel\Pulse\Ingests;
 
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Redis\RedisManager;
 use Illuminate\Support\Collection;
 use Laravel\Pulse\Contracts\Ingest;

--- a/src/Recorders/Exceptions.php
+++ b/src/Recorders/Exceptions.php
@@ -3,7 +3,7 @@
 namespace Laravel\Pulse\Recorders;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;

--- a/src/Recorders/Queues.php
+++ b/src/Recorders/Queues.php
@@ -3,7 +3,7 @@
 namespace Laravel\Pulse\Recorders;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Pulse\Recorders;
 
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\Str;
 use Laravel\Pulse\Events\SharedBeat;
 use Laravel\Pulse\Pulse;

--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -3,7 +3,7 @@
 namespace Laravel\Pulse\Recorders;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Str;
 use Laravel\Pulse\Pulse;

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -5,7 +5,7 @@ namespace Laravel\Pulse\Storage;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Closure;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Query\Builder;

--- a/src/Support/CacheStoreResolver.php
+++ b/src/Support/CacheStoreResolver.php
@@ -3,7 +3,7 @@
 namespace Laravel\Pulse\Support;
 
 use Illuminate\Cache\CacheManager;
-use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
 class CacheStoreResolver

--- a/src/Support/CacheStoreResolver.php
+++ b/src/Support/CacheStoreResolver.php
@@ -3,8 +3,8 @@
 namespace Laravel\Pulse\Support;
 
 use Illuminate\Cache\CacheManager;
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
 class CacheStoreResolver
 {

--- a/src/Support/RedisAdapter.php
+++ b/src/Support/RedisAdapter.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Pulse\Support;
 
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Collection;
 use Predis\Client as Predis;

--- a/tests/Feature/RedisTest.php
+++ b/tests/Feature/RedisTest.php
@@ -16,7 +16,7 @@ use Tests\StorageFake;
 
 $drivers = ['predis', 'phpredis', 'relay'];
 
-function skipWhenExtensionMissing($driver)
+function prepareForDriver($driver)
 {
     $extension = match ($driver) {
         'phpredis' => 'redis',
@@ -29,6 +29,11 @@ function skipWhenExtensionMissing($driver)
             ? test()->markTestSkipped("PHP extension [{$extension}] missing for Redis driver [{$driver}].")
             : null,
     };
+
+    // Relay version 0.8.0 introduced a breaking change that requires the port be an integer.
+    if ($driver === 'relay') {
+        Config::set('database.redis.default.port', (int) Config::get('database.redis.default.port'));
+    };
 }
 
 beforeEach(function () {
@@ -40,7 +45,7 @@ beforeEach(function () {
 });
 
 it('runs the same commands while ingesting entries', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
 
@@ -52,7 +57,7 @@ it('runs the same commands while ingesting entries', function ($driver) {
 })->with($drivers);
 
 it('keeps 7 days of data, by default, when trimming', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
@@ -63,7 +68,7 @@ it('keeps 7 days of data, by default, when trimming', function ($driver) {
 })->with($drivers);
 
 it('can configure days of data to keep when trimming', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
@@ -75,7 +80,7 @@ it('can configure days of data to keep when trimming', function ($driver) {
 })->with($drivers);
 
 it('can configure the number of entries to keep when trimming', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     Date::setTestNow(Date::parse('2000-01-02 03:04:05')->startOfSecond());
@@ -87,7 +92,7 @@ it('can configure the number of entries to keep when trimming', function ($drive
 })->with($drivers);
 
 it('runs the same commands while storing', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     Config::set('pulse.ingest.redis.chunk', 567);
@@ -110,7 +115,7 @@ it('runs the same commands while storing', function ($driver) {
 })->with($drivers);
 
 it('has consistent return for xadd', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
@@ -128,7 +133,7 @@ it('has consistent return for xadd', function ($driver) {
 })->with($drivers);
 
 it('has consistent return for xrange', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
@@ -159,7 +164,7 @@ it('has consistent return for xrange', function ($driver) {
 })->with($drivers);
 
 it('has consistent return for xtrim', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));
@@ -186,7 +191,7 @@ it('has consistent return for xtrim', function ($driver) {
 })->with($drivers);
 
 it('throws exception on failure', function ($driver) {
-    skipWhenExtensionMissing($driver);
+    prepareForDriver($driver);
 
     Config::set('database.redis.client', $driver);
     $redis = new RedisAdapter(Redis::connection(), App::make('config'));

--- a/tests/Feature/RedisTest.php
+++ b/tests/Feature/RedisTest.php
@@ -33,7 +33,7 @@ function prepareForDriver($driver)
     // Relay version 0.8.0 introduced a breaking change that requires the port be an integer.
     if ($driver === 'relay') {
         Config::set('database.redis.default.port', (int) Config::get('database.redis.default.port'));
-    };
+    }
 }
 
 beforeEach(function () {


### PR DESCRIPTION
Re-attemping https://github.com/laravel/pulse/pull/375

Switches injection concrete implementations with their contracts instead. This doesn't cover all possible classes, but should cover the ones people might actually modify.