### PR TITLE
[1.x] Ensure first-party CSS is not overriden

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -495,7 +495,7 @@ class Pulse
     public function css(string|Htmlable|array|null $css = null): string|self
     {
         if (func_num_args() === 1) {
-            $this->css = array_values(array_unique(array_merge($this->css, Arr::wrap($css)), SORT_REGULAR));
+            $this->css = array_values(array_unique(array_merge(Arr::wrap($css), $this->css), SORT_REGULAR));
 
             return $this;
         }


### PR DESCRIPTION
When a 3rd party card adds CSS it currently overrides existing CSS.

This _sounds_ like a good thing and what we want, however due to the nature of Tailwind + the cascade, unwanted styling occurs.

For example, imagine a 3rd party card that uses the `block` class in Tailwind.

Because its `.block { display: block }` appears later in the order it will override undo some styling in the Pulse dashboard.

```html
<button class="block dark:hidden">
```

This button will now _always_ be visible.