### PR TITLE
allow pulse title to be changed

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -8,6 +8,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Pulse App Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the name of your application. This value is used when the
+    | framework needs to display the name of the application within the UI
+    | or in other locations. Of course, you're free to change the value.
+    |
+    */
+    'name' => env('PULSE_APP_NAME', '<b class="font-bold">Laravel</b> Pulse'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Pulse Domain
     |--------------------------------------------------------------------------
     |

--- a/resources/views/components/pulse.blade.php
+++ b/resources/views/components/pulse.blade.php
@@ -6,7 +6,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title inertia>Laravel Pulse</title>
+        <title inertia>{{ strip_tags(config('pulse.name')) }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
@@ -34,7 +34,7 @@
                                     </linearGradient>
                                 </defs>
                             </svg>
-                            <span class="ml-2 text-lg sm:text-2xl text-gray-700 dark:text-gray-300 font-medium"><b class="font-bold">Laravel</b> Pulse</span>
+                            <span class="ml-2 text-lg sm:text-2xl text-gray-700 dark:text-gray-300 font-medium">{!! config('pulse.name') !!}</span>
                         </div>
                         <div class="flex items-center gap-3 sm:gap-6">
                             <livewire:pulse.period-selector />


### PR DESCRIPTION
I have a few sites with pulse installed, if i can change the name, it will be easier for me to differentiate between this is pulse for site A, site B, site C.etc. Rather than all my tabs and page header being called "Laravel Pulse"

If this is approved, i hope you will be open to telescope, horizon.etc having the same changes too

you can also change it to title instead of name if you want. I chose name since that is what Nova use in its config file. The description docs above the name is also taken from Nova with some slight changes