### PR TITLE
Use the App Name for Pulse dashboard header & browser title instead

### DIFF
--- a/resources/views/components/pulse.blade.php
+++ b/resources/views/components/pulse.blade.php
@@ -6,7 +6,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title inertia>Laravel Pulse</title>
+        <title inertia>{{ config('app.name') }} Pulse</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
@@ -34,7 +34,7 @@
                                     </linearGradient>
                                 </defs>
                             </svg>
-                            <span class="ml-2 text-lg sm:text-2xl text-gray-700 dark:text-gray-300 font-medium"><b class="font-bold">Laravel</b> Pulse</span>
+                            <span class="ml-2 text-lg sm:text-2xl text-gray-700 dark:text-gray-300 font-medium"><b class="font-bold">{{ config('app.name') }}</b> Pulse</span>
                         </div>
                         <div class="flex items-center gap-3 sm:gap-6">
                             <livewire:pulse.period-selector />


### PR DESCRIPTION
Yesterday I made a PR adding a `config('pulse.name')` to allow the title of the Pulse Dashboard to be changed

https://github.com/laravel/pulse/pull/383

However Taylor closed it as Taylor prefer to just use `config('app.name')`

> Not sure this needs it's own configuration option. We could just make the title read the app.name.



So this is a new PR doing that.

So it will look like this

![CleanShot 2024-05-29 at 12 08 52@2x](https://github.com/laravel/pulse/assets/679513/740e4487-ea00-4b6b-b744-c5b50bcf9697)

And the browser tab title

![CleanShot 2024-05-29 at 12 09 19@2x](https://github.com/laravel/pulse/assets/679513/f654a195-68c2-449c-a14b-4d29db204d70)

I hope you will be open to this change making it to horizon & telescope too