### PR TITLE
Skip unreadable filesystems

### DIFF
--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -86,7 +86,7 @@ class Servers
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
                 'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->filter(fn (string $directory) => rescue(fn () => disk_total_space($directory), false, false) !== false)
+                    ->filter(fn (string $directory) => @disk_total_space($directory) !== false)
                     ->map(fn (string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -86,7 +86,7 @@ class Servers
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
                 'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->filter(fn (string $directory) => @disk_total_space($directory) !== false)
+                    ->filter(fn (string $directory) => rescue(fn () => disk_total_space($directory), false) !== false)
                     ->map(fn (string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -86,6 +86,7 @@ class Servers
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
                 'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
+                    ->filter(fn (string $directory) => rescue(fn () => disk_total_space($directory), false, false) !== false)
                     ->map(fn (string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -86,7 +86,7 @@ class Servers
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
                 'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->filter(fn (string $directory) => rescue(fn () => disk_total_space($directory), false) !== false)
+                    ->filter(fn (string $directory) => ($this->pulse->rescue(fn () => disk_total_space($directory)) ?? false) !== false)
                     ->map(fn (string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB

--- a/tests/Feature/Recorders/ServersTest.php
+++ b/tests/Feature/Recorders/ServersTest.php
@@ -62,3 +62,16 @@ it('can customise CPU and memory resolution', function () {
     Servers::detectCpuUsing(null);
     Servers::detectMemoryUsing(null);
 });
+
+it('skips missing filesystems when recording events', function () {
+    Config::set('pulse.recorders.'.Servers::class . '.directories', ['/', '/nonexistent']);
+    Date::setTestNow(Date::now()->startOfMinute());
+
+    event(new SharedBeat(CarbonImmutable::now(), 'instance-id'));
+    Pulse::ingest();
+
+    $value = Pulse::ignore(fn () => DB::table('pulse_values')->sole());
+
+    $payload = json_decode($value->value);
+    expect($payload->storage)->toHaveCount(1);
+});

--- a/tests/Feature/Recorders/ServersTest.php
+++ b/tests/Feature/Recorders/ServersTest.php
@@ -64,6 +64,9 @@ it('can customise CPU and memory resolution', function () {
 });
 
 it('skips missing filesystems when recording events', function () {
+    Pulse::handleExceptionsUsing(function () {
+        //
+    });
     Config::set('pulse.recorders.'.Servers::class . '.directories', ['/', '/nonexistent']);
     Date::setTestNow(Date::now()->startOfMinute());
 


### PR DESCRIPTION
Hi,

If your server loses a monitored storage mount point then `disk_total_space()` will throw an exception. This causes Pulse to stop logging the current "value".

This PR filters out filesystems that cannot be read at the moment, at least allowing Pulse to present the data it can get hold of.