### PR TITLE
[1.x] Fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/sql-formatter": "^1.2",
         "guzzlehttp/promises": "^1.0|^2.0",
+        "doctrine/sql-formatter": "^1.4.1",
         "illuminate/auth": "^10.48.4|^11.0.8",
         "illuminate/cache": "^10.48.4|^11.0.8",
         "illuminate/config": "^10.48.4|^11.0.8",


### PR DESCRIPTION
Locking the SQL highlighting package to the latest release. A recent revert changed how they capitalised reserved words. Locking to the latest will ensure that our testsuite passes on latest and `prefer-lowest` settings.