### PR TITLE
Allow rebranding of Page Title and Logo

### DIFF
--- a/resources/views/components/pulse.blade.php
+++ b/resources/views/components/pulse.blade.php
@@ -1,12 +1,12 @@
 @use('Laravel\Pulse\Facades\Pulse')
-@props(['cols' => 12, 'fullWidth' => false])
+@props(['cols' => 12, 'fullWidth' => false, 'pageTitle' => 'Laravel Pulse'])
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title inertia>Laravel Pulse</title>
+        <title inertia>{{ $pageTitle }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
@@ -25,6 +25,7 @@
                 <div class="{{ $fullWidth ? '' : 'container' }} py-3 sm:py-5 mx-auto border-b border-gray-200 dark:border-gray-900">
                     <div class="flex items-center justify-between">
                         <div class="flex items-center">
+                          @if ($brand->isEmpty())
                             <svg width="33" height="32" viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path fill-rule="evenodd" clip-rule="evenodd" d="M15.4566 6.75005C15.9683 6.75596 16.4047 7.09621 16.5001 7.56364L18.8747 19.2038L19.999 17.1682C20.1832 16.8347 20.5526 16.625 20.9559 16.625H31.1744C31.7684 16.625 32.25 17.0727 32.25 17.625C32.25 18.1773 31.7684 18.625 31.1744 18.625H21.6127L19.3581 22.7068C19.1483 23.0867 18.7021 23.3008 18.2475 23.2397C17.7928 23.1786 17.4301 22.8559 17.3445 22.4363L15.376 12.7868L13.1334 22.4607C13.0282 22.9146 12.6007 23.2414 12.1013 23.2498C11.6019 23.2582 11.162 22.9458 11.0393 22.4957L9.30552 16.1378L8.19223 18.0929C8.00581 18.4202 7.64002 18.625 7.2416 18.625H1.32563C0.731576 18.625 0.25 18.1773 0.25 17.625C0.25 17.0727 0.731576 16.625 1.32563 16.625H6.59398L8.71114 12.9071C8.9193 12.5415 9.34805 12.3328 9.78979 12.3821C10.2315 12.4313 10.5951 12.7283 10.7044 13.1292L11.9971 17.8695L14.3918 7.53929C14.4996 7.07421 14.9449 6.74414 15.4566 6.75005Z" fill="url(#paint0_linear_4_31)"/>
                                 <defs>
@@ -35,6 +36,9 @@
                                 </defs>
                             </svg>
                             <span class="ml-2 text-lg sm:text-2xl text-gray-700 dark:text-gray-300 font-medium"><b class="font-bold">Laravel</b> Pulse</span>
+                          @else
+                            {{ $brand }}
+                          @endif
                         </div>
                         <div class="flex items-center gap-3 sm:gap-6">
                             <livewire:pulse.period-selector />


### PR DESCRIPTION
This PR adds some basic flexibility so anyone can take the pulse page and white-label it as part of their own application. This does not break features and adds extensibility. 

I didn't write tests for this as there's such a thing as too many tests, and I worry this would be over-testing. If you would like a test for ensuring the slot data is overwritten, I'm happy to take a look?

_I've enabled maintainer editability._

![image](https://github.com/user-attachments/assets/f793c675-c1bb-4281-ae81-67f100ebbbff)

