### PR TITLE
[1.x] Add Support for Custom Periods

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -123,6 +123,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Pulse Periods
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the "periods" that will be available to select
+    | from the Pulse dashboard. You may modify this array as you wish, but
+    | ensure that the key is the period and the value is the hours.
+    |
+    */
+
+    'periods' => [
+        '1h' => 1,
+        '6h' => 6,
+        '24h' => 24,
+        '7d' => 168,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Pulse Recorders
     |--------------------------------------------------------------------------
     |

--- a/resources/views/livewire/period-selector.blade.php
+++ b/resources/views/livewire/period-selector.blade.php
@@ -12,8 +12,7 @@
         }
     }"
 >
-    <button @click="setPeriod('1_hour')" class="p-1 font-semibold sm:text-lg {{ $period === '1_hour' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">1h</button>
-    <button @click="setPeriod('6_hours')" class="p-1 font-semibold sm:text-lg {{ $period === '6_hours' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">6h</button>
-    <button @click="setPeriod('24_hours')" class="p-1 font-semibold sm:text-lg {{ $period === '24_hours' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">24h</button>
-    <button @click="setPeriod('7_days')" class="p-1 font-semibold sm:text-lg {{ $period === '7_days' ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">7d</button>
+    @foreach(array_keys($periods) as $period)
+        <button @click="setPeriod('{{ $period }}')" class="p-1 font-semibold sm:text-lg {{ $current === $period ? 'text-gray-700 dark:text-gray-300' : 'text-gray-300 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-500'}}">{{ $period }}</button>
+    @endforeach
 </div>

--- a/src/Livewire/Concerns/HasPeriod.php
+++ b/src/Livewire/Concerns/HasPeriod.php
@@ -15,6 +15,8 @@ trait HasPeriod
 
     /**
      * The default periods.
+     *
+     * @var array<string, int>
      */
     public array $defaults = [
         '1h' => 1,
@@ -25,6 +27,8 @@ trait HasPeriod
 
     /**
      * The available periods.
+     *
+     * @return array<string, int>
      */
     public function periods(): array
     {
@@ -47,7 +51,7 @@ trait HasPeriod
         return collect($this->periods())
             ->map(fn (int $hours, string $key): array => [
                 'key' => $key,
-                'label' => $hours,
+                'label' => (string) $hours,
             ])
             ->firstWhere('key', '=', $this->period)['label'] ?? '1h';
     }

--- a/src/Livewire/PeriodSelector.php
+++ b/src/Livewire/PeriodSelector.php
@@ -4,7 +4,6 @@ namespace Laravel\Pulse\Livewire;
 
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\View;
-use Livewire\Attributes\Url;
 use Livewire\Component;
 
 /**
@@ -12,19 +11,16 @@ use Livewire\Component;
  */
 class PeriodSelector extends Component
 {
-    /**
-     * The selected period.
-     *
-     * @var '1_hour'|'6_hours'|'24_hours'|'7_days'
-     */
-    #[Url]
-    public string $period = '1_hour';
+    use Concerns\HasPeriod;
 
     /**
      * Render the component.
      */
     public function render(): Renderable
     {
-        return View::make('pulse::livewire.period-selector');
+        return View::make('pulse::livewire.period-selector', [
+            'periods' => $this->periods(),
+            'current' => $this->period,
+        ]);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to introduce support for custom periods via config file.

### Demonstration

The config file:

```php
/*
|--------------------------------------------------------------------------
| Pulse Periods
|--------------------------------------------------------------------------
|
| The following array lists the "periods" that will be available to select
| from the Pulse dashboard. You may modify this array as you wish, but
| ensure that the key is the period and the value is the hours.
|
*/

'periods' => [
    '1h' => 1,
    '6h' => 6,
    '24h' => 24,
    '7d' => 168,

    // customs 👇🏻 

    '30d' => 720,
    '7w' => 1_176,
],
```

The dashboard:

![CleanShot 2024-09-30 at 21 05 46](https://github.com/user-attachments/assets/04ef8996-e12a-47dd-a613-0ec872de53a7)

### Note

Although with this PR the name of the period-related prefixes will be changed, for example: `6_hours` to `6h`, I don't believe there will be any breaking changes. Also, we have the "default" period saved internally, to make this PR be compatible with published configuration files.

### Tests

I haven't been able to identify an exact way to test this. All current tests continue to pass so I think this is sufficient. I'm open to suggestions on how to introduce tests.