### PR TITLE
Fix `createFromTimestamp()` to use correct timezone

### DIFF
--- a/src/Livewire/Exceptions.php
+++ b/src/Livewire/Exceptions.php
@@ -43,7 +43,7 @@ class Exceptions extends Card
                 return (object) [
                     'class' => $class,
                     'location' => $location,
-                    'latest' => CarbonImmutable::createFromTimestamp($row->max),
+                    'latest' => CarbonImmutable::createFromTimestamp($row->max, config('app.timezone', 'UTC')),
                     'count' => $row->count,
                 ];
             }),

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -44,7 +44,7 @@ class Servers extends Card
                         'memory_total' => (int) $values->memory_total,
                         'memory' => $graphs->get($slug)?->get('memory') ?? collect(),
                         'storage' => collect($values->storage), // @phpstan-ignore argument.templateType, argument.templateType
-                        'updated_at' => $updatedAt = CarbonImmutable::createFromTimestamp($system->timestamp),
+                        'updated_at' => $updatedAt = CarbonImmutable::createFromTimestamp($system->timestamp, config('app.timezone', 'UTC')),
                         'recently_reported' => $updatedAt->isAfter(now()->subSeconds(30)),
                     ];
                 })
@@ -86,6 +86,6 @@ class Servers extends Card
             ? (int) $this->ignoreAfter
             : CarbonInterval::createFromDateString($this->ignoreAfter)->totalSeconds;
 
-        return CarbonImmutable::createFromTimestamp($system->timestamp)->addSeconds($ignoreAfter)->isPast();
+        return CarbonImmutable::createFromTimestamp($system->timestamp, config('app.timezone', 'UTC'))->addSeconds($ignoreAfter)->isPast();
     }
 }

--- a/src/Recorders/Concerns/Throttling.php
+++ b/src/Recorders/Concerns/Throttling.php
@@ -31,7 +31,7 @@ trait Throttling
 
         $lastRunAt = $cache->store()->get($key);
 
-        if ($lastRunAt !== null && CarbonImmutable::createFromTimestamp($lastRunAt)->addSeconds($this->secondsUntil($interval))->isFuture()) {
+        if ($lastRunAt !== null && CarbonImmutable::createFromTimestamp($lastRunAt, config('app.timezone', 'UTC'))->addSeconds($this->secondsUntil($interval))->isFuture()) {
             return;
         }
 

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -476,7 +476,7 @@ class DatabaseStorage implements Storage
 
         $padding = collect()
             ->range(0, 59)
-            ->mapWithKeys(fn ($i) => [CarbonImmutable::createFromTimestamp($firstBucket + $i * $secondsPerPeriod)->toDateTimeString() => null]);
+            ->mapWithKeys(fn ($i) => [CarbonImmutable::createFromTimestamp($firstBucket + $i * $secondsPerPeriod, config('app.timezone', 'UTC'))->toDateTimeString() => null]);
 
         $structure = collect($types)->mapWithKeys(fn ($type) => [$type => $padding]);
 
@@ -494,7 +494,7 @@ class DatabaseStorage implements Storage
                 ->groupBy('type')
                 ->map(fn ($readings) => $padding->merge(
                     $readings->mapWithKeys(function ($reading) {
-                        return [CarbonImmutable::createFromTimestamp($reading->bucket)->toDateTimeString() => $reading->value];
+                        return [CarbonImmutable::createFromTimestamp($reading->bucket, config('app.timezone', 'UTC'))->toDateTimeString() => $reading->value];
                     })
                 ))
             ));

--- a/tests/Feature/Livewire/QueuesTest.php
+++ b/tests/Feature/Livewire/QueuesTest.php
@@ -39,18 +39,18 @@ it('renders queue statistics', function () {
         ->assertViewHas('queues', collect([
             'database:default' => collect([
                 'queued' => collect()
-                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
-                    ->put(Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->toDateTimeString(), 4),
+                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
+                    ->put(Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->toDateTimeString(), 4),
                 'processing' => collect()
-                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
-                    ->put(Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->toDateTimeString(), 3),
+                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
+                    ->put(Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->toDateTimeString(), 3),
                 'processed' => collect()
-                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
-                    ->put(Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->toDateTimeString(), 2),
+                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
+                    ->put(Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->toDateTimeString(), 2),
                 'released' => collect()
-                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
-                    ->put(Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->toDateTimeString(), 1),
-                'failed' => collect()->range(59, 0)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->subMinutes($i)->toDateTimeString() => null]),
+                    ->range(59, 1)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
+                    ->put(Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->toDateTimeString(), 1),
+                'failed' => collect()->range(59, 0)->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->subMinutes($i)->toDateTimeString() => null]),
             ]),
         ]))
         ->assertViewHas('showConnection', false);

--- a/tests/Feature/Livewire/ServersTest.php
+++ b/tests/Feature/Livewire/ServersTest.php
@@ -49,12 +49,12 @@ it('renders server statistics', function () {
                     (object) ['directory' => '/', 'used' => 123, 'total' => 456],
                 ]),
                 'cpu' => collect()->range(59, 1)
-                    ->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
-                    ->put(Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->toDateTimeString(), 50),
+                    ->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
+                    ->put(Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->toDateTimeString(), 50),
                 'memory' => collect()->range(59, 1)
-                    ->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
-                    ->put(Carbon::createFromTimestamp(now()->timestamp)->startOfMinute()->toDateTimeString(), 1500),
-                'updated_at' => CarbonImmutable::createFromTimestamp(now()->timestamp),
+                    ->mapWithKeys(fn ($i) => [Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->subMinutes($i)->toDateTimeString() => null])
+                    ->put(Carbon::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC'))->startOfMinute()->toDateTimeString(), 1500),
+                'updated_at' => CarbonImmutable::createFromTimestamp(now()->timestamp, config('app.timezone', 'UTC')),
                 'recently_reported' => true,
             ],
         ]));


### PR DESCRIPTION
In version 3 of Carbon, there has been [a change in the way the `createFromTimestamp()` function works](https://carbon.nesbot.com/docs/#api-carbon-3-create-from-timestamp-utc) when no timezone is specified. In version 2, this function took the timezone defined in PHP settings. Currently it uses the `UTC` zone. This causes incorrect values to be displayed on the timeline in Pulse charts.

This pull request implements a change suggested by the Carbon author, i.e. it adds a second parameter to the `createFromTimestamp()` function call, which is the timezone defined in the application settings, with the default value still being `UTC`. Additionally, this makes Laravel Pulse work consistently across applications using Carbon 2 and Carbon 3.

Fixes #410 