### PR TITLE
Draft: SQL Server support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,3 +229,58 @@ jobs:
         run: vendor/bin/pest -vvv
         env:
           DB_CONNECTION: sqlite
+
+  sqlsrv:
+    runs-on: ubuntu-22.04
+
+    services:
+      sqlsrv:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'sTr0ngP@ssw0rd!'
+        ports:
+          - 1433:1433
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.3]
+        laravel: [11]
+        stability: [prefer-stable]
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - SQL Server 2022
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, redis, pcntl, zip, relay, sqlsrv, pdo_sqlsrv, odbc, pdo_odbc,
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install redis-cli
+        run: sudo apt-get install -qq redis-tools
+
+      - name: Install dependencies
+        run: |
+          composer require cachewerk/relay --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
+
+      - name: Execute tests
+        run: vendor/bin/pest -vvv
+        env:
+          DB_CONNECTION: sqlsrv
+          DB_DATABASE: master
+          DB_USERNAME: sa
+          DB_PASSWORD: 'sTr0ngP@ssw0rd!'

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -24,6 +24,7 @@ return new class extends PulseMigration
                 'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
+                'sqlsrv' => $table->string('key_hash', 32),
             };
             $table->mediumText('value');
 
@@ -41,6 +42,7 @@ return new class extends PulseMigration
                 'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
+                'sqlsrv' => $table->string('key_hash', 32),
             };
             $table->bigInteger('value')->nullable();
 
@@ -60,6 +62,7 @@ return new class extends PulseMigration
                 'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
+                'sqlsrv' => $table->string('key_hash', 32),
             };
             $table->string('aggregate');
             $table->decimal('value', 20, 2);

--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -24,7 +24,7 @@ class PulseMigration extends Migration
      */
     protected function shouldRun(): bool
     {
-        if (in_array($this->driver(), ['mariadb', 'mysql', 'pgsql', 'sqlite'])) {
+        if (in_array($this->driver(), ['mariadb', 'mysql', 'pgsql', 'sqlite', 'sqlsrv'])) {
             return true;
         }
 

--- a/tests/Feature/Recorders/SlowJobsTest.php
+++ b/tests/Feature/Recorders/SlowJobsTest.php
@@ -100,7 +100,7 @@ it('can configure threshold per job', function () {
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->get());
     expect($entries)->toHaveCount(1);
     expect($entries[0]->key)->toBe('MySlowJob');
-    expect($entries[0]->value)->toBe(1_000);
+    expect($entries[0]->value)->toEqual(1_000);
 
     DB::table('pulse_entries')->delete();
 
@@ -111,9 +111,9 @@ it('can configure threshold per job', function () {
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'slow_job')->get());
     expect($entries)->toHaveCount(2);
     expect($entries[0]->key)->toBe('MySlowJob');
-    expect($entries[0]->value)->toBe(2_000);
+    expect($entries[0]->value)->toEqual(2_000);
     expect($entries[1]->key)->toBe('AnotherSlowJob');
-    expect($entries[1]->value)->toBe(2_000);
+    expect($entries[1]->value)->toEqual(2_000);
 });
 
 it('can ignore jobs', function () {

--- a/tests/Feature/Recorders/SlowOutgoingRequestsTest.php
+++ b/tests/Feature/Recorders/SlowOutgoingRequestsTest.php
@@ -252,7 +252,7 @@ it('can configure threshold per url', function () {
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
     expect($entries[0]->key)->toBe('["GET","one-second-threshold"]');
-    expect($entries[0]->value)->toBe(1000);
+    expect($entries[0]->value)->toEqual(1000);
 
     DB::table('pulse_entries')->delete();
 
@@ -264,7 +264,7 @@ it('can configure threshold per url', function () {
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->orderBy('key')->get());
     expect($entries)->toHaveCount(2);
     expect($entries[0]->key)->toBe('["GET","one-second-threshold"]');
-    expect($entries[0]->value)->toBe(2_000);
+    expect($entries[0]->value)->toEqual(2_000);
     expect($entries[1]->key)->toBe('["GET","two-second-threshold"]');
-    expect($entries[1]->value)->toBe(2_000);
+    expect($entries[1]->value)->toEqual(2_000);
 });

--- a/tests/Feature/Recorders/SlowQueriesTest.php
+++ b/tests/Feature/Recorders/SlowQueriesTest.php
@@ -129,7 +129,7 @@ it('can configure threshold per query', function () {
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
     expect($entries)->toHaveCount(1);
     expect($entries[0]->key)->toContain('one_second_threshold');
-    expect($entries[0]->value)->toBe(1_000);
+    expect($entries[0]->value)->toEqual(1_000);
 
     Pulse::ignore(fn () => DB::table('pulse_entries')->delete());
 
@@ -143,9 +143,9 @@ it('can configure threshold per query', function () {
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->orderBy('key')->get());
     expect($entries)->toHaveCount(2);
     expect($entries[0]->key)->toContain('one_second_threshold');
-    expect($entries[0]->value)->toBe(2_000);
+    expect($entries[0]->value)->toEqual(2_000);
     expect($entries[1]->key)->toContain('two_second_threshold');
-    expect($entries[1]->value)->toBe(2_000);
+    expect($entries[1]->value)->toEqual(2_000);
 });
 
 it('ingests queries equal to the slow query threshold', function () {

--- a/tests/Feature/Recorders/SlowRequestsTest.php
+++ b/tests/Feature/Recorders/SlowRequestsTest.php
@@ -30,7 +30,7 @@ it('captures requests over the threshold', function () {
     expect($entries[0]->type)->toBe('slow_request');
     expect($entries[0]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($entries[0]->value)->toBe(4000);
+    expect($entries[0]->value)->toEqual(4000);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('type')->orderBy('period')->orderBy('aggregate')->get());
     expect($aggregates)->toHaveCount(8);
@@ -126,7 +126,7 @@ it('can configure threshold per route', function () {
     expect($entries[0]->type)->toBe('slow_request');
     expect($entries[0]->key)->toBe(json_encode(['GET', '/one-second-threshold', 'Closure']));
     expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/one-second-threshold', 'Closure'])));
-    expect($entries[0]->value)->toBe(1000);
+    expect($entries[0]->value)->toEqual(1000);
 
     DB::table('pulse_entries')->delete();
 
@@ -140,11 +140,11 @@ it('can configure threshold per route', function () {
     expect($entries[0]->type)->toBe('slow_request');
     expect($entries[0]->key)->toBe(json_encode(['GET', '/one-second-threshold', 'Closure']));
     expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/one-second-threshold', 'Closure'])));
-    expect($entries[0]->value)->toBe(2000);
+    expect($entries[0]->value)->toEqual(2000);
     expect($entries[1]->type)->toBe('slow_request');
     expect($entries[1]->key)->toBe(json_encode(['GET', '/two-second-threshold', 'Closure']));
     expect($entries[1]->key_hash)->toBe(keyHash(json_encode(['GET', '/two-second-threshold', 'Closure'])));
-    expect($entries[1]->value)->toBe(2000);
+    expect($entries[1]->value)->toEqual(2000);
 });
 
 it('captures slow requests per user', function () {
@@ -317,7 +317,7 @@ it('captures the requests "via" route when using livewire', function () {
     expect($entries[0]->type)->toBe('slow_request');
     expect($entries[0]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($entries[0]->value)->toBe(4000);
+    expect($entries[0]->value)->toEqual(4000);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('type')->orderBy('period')->orderBy('aggregate')->get());
     expect($aggregates)->toHaveCount(8);

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -480,7 +480,7 @@ test('total aggregate for multiple types', function () {
 it('collapses values with the same key into a single upsert', function () {
     $bindings = [];
     DB::listen(function (QueryExecuted $event) use (&$bindings) {
-        if (str_starts_with($event->sql, 'insert')  || str_starts_with($event->sql, 'merge')) {
+        if (str_starts_with($event->sql, 'insert') || str_starts_with($event->sql, 'merge')) {
             $bindings = $event->bindings;
         }
     });

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -124,7 +124,7 @@ test('aggregation', function () {
 it('combines duplicate count aggregates before upserting', function () {
     $queries = collect();
     DB::listen(function (QueryExecuted $event) use (&$queries) {
-        if (str_starts_with($event->sql, 'insert')) {
+        if (str_starts_with($event->sql, 'insert') || str_starts_with($event->sql, 'merge')) {
             $queries[] = $event;
         }
     });
@@ -138,7 +138,7 @@ it('combines duplicate count aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
+    if (in_array(DB::connection()->getDriverName(), ['sqlite', 'sqlsrv'])) {
         expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
         expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
     } else {
@@ -154,7 +154,7 @@ it('combines duplicate count aggregates before upserting', function () {
 it('combines duplicate min aggregates before upserting', function () {
     $queries = collect();
     DB::listen(function (QueryExecuted $event) use (&$queries) {
-        if (str_starts_with($event->sql, 'insert')) {
+        if (str_starts_with($event->sql, 'insert') || str_starts_with($event->sql, 'merge')) {
             $queries[] = $event;
         }
     });
@@ -168,7 +168,7 @@ it('combines duplicate min aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
+    if (in_array(DB::connection()->getDriverName(), ['sqlite', 'sqlsrv'])) {
         expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
         expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
     } else {
@@ -184,7 +184,7 @@ it('combines duplicate min aggregates before upserting', function () {
 it('combines duplicate max aggregates before upserting', function () {
     $queries = collect();
     DB::listen(function (QueryExecuted $event) use (&$queries) {
-        if (str_starts_with($event->sql, 'insert')) {
+        if (str_starts_with($event->sql, 'insert') || str_starts_with($event->sql, 'merge')) {
             $queries[] = $event;
         }
     });
@@ -198,7 +198,7 @@ it('combines duplicate max aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
+    if (in_array(DB::connection()->getDriverName(), ['sqlite', 'sqlsrv'])) {
         expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
         expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
     } else {
@@ -214,7 +214,7 @@ it('combines duplicate max aggregates before upserting', function () {
 it('combines duplicate sum aggregates before upserting', function () {
     $queries = collect();
     DB::listen(function (QueryExecuted $event) use (&$queries) {
-        if (str_starts_with($event->sql, 'insert')) {
+        if (str_starts_with($event->sql, 'insert') || str_starts_with($event->sql, 'merge')) {
             $queries[] = $event;
         }
     });
@@ -228,7 +228,7 @@ it('combines duplicate sum aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
+    if (in_array(DB::connection()->getDriverName(), ['sqlite', 'sqlsrv'])) {
         expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
         expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
     } else {
@@ -244,7 +244,7 @@ it('combines duplicate sum aggregates before upserting', function () {
 it('combines duplicate average aggregates before upserting', function () {
     $queries = collect();
     DB::listen(function (QueryExecuted $event) use (&$queries) {
-        if (str_starts_with($event->sql, 'insert')) {
+        if (str_starts_with($event->sql, 'insert') || str_starts_with($event->sql, 'merge')) {
             $queries[] = $event;
         }
     });
@@ -258,7 +258,7 @@ it('combines duplicate average aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
+    if (in_array(DB::connection()->getDriverName(), ['sqlite', 'sqlsrv'])) {
         expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
         expect($queries[1]->bindings)->toHaveCount(2 * 8 * 4); // 2 entries, 8 columns each, 4 periods
     } else {
@@ -480,7 +480,7 @@ test('total aggregate for multiple types', function () {
 it('collapses values with the same key into a single upsert', function () {
     $bindings = [];
     DB::listen(function (QueryExecuted $event) use (&$bindings) {
-        if (str_starts_with($event->sql, 'insert')) {
+        if (str_starts_with($event->sql, 'insert')  || str_starts_with($event->sql, 'merge')) {
             $bindings = $event->bindings;
         }
     });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -105,7 +105,7 @@ function keyHash(string $string): string
     return match (DB::connection()->getDriverName()) {
         'mariadb', 'mysql' => hex2bin(md5($string)),
         'pgsql' => Uuid::fromString(md5($string)),
-        'sqlite' => md5($string),
+        'sqlite', 'sqlsrv' => md5($string),
     };
 }
 


### PR DESCRIPTION
This one still needs a bit of work to do.

1. Since SQL Server upsert works with the `merge` statement in Laravel, we need to rely on a physical key_hash column with pre-generated hashes like in sqlite and cannot go the mysql, mariadb and postgres way by using a virtual column - even if SQL Server supports this by using [computed columns](https://learn.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table?view=sql-server-ver16). A quick example on that:
    ```sql
    merge [pulse_values] using (values ('key', timestamp, 'type', value)) [laravel_source] ([key], [timestamp], [type], [value])
    on [laravel_source].[type] = [pulse_values].[type] and [laravel_source].[key_hash] = [pulse_values].[key_hash]
    ```
    This issue lies in `laravel_source` (the source table to be compared in the merge statement) not having the `key_hash` column 
    \- this makes the join condition `[laravel_source].[key_hash] = [pulse_values].[key_hash]` invalid.

    We could create computed columns for the `key_hash`...:
    ```php
        'sqlsrv' => $table->computed('key_hash', 'cast(hashbytes(\'md5\', [key]) as uniqueidentifier)'),
    ```
    ... but doing that, we will get a SQL Error because the `merge` query will try to insert or update the `key_hash` column - which is 
    not possible, because this one is a non-writable, computed value. That's why I went with creating a string with the length of 
    32, which is the md5 string representation.

2. I am using `[laravel_source]` as hard coded alias for the upserts, since the current implementation in Laravel also does that. See as seen in [SqlGrammar::compileUpsert()](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php#L425-L438)

---

This one still needs a bit of work with some digging being involved. Another issue that I've been facing is the problem of the sqlsrv driver returning values as a string - that results in failing test with messages like...
> Failed asserting that '946782245' is identical to 946782245.

and  
> Failed asserting that '1000' is identical to 1000.

or  

> Failed asserting that '1729617300' is identical to 1729617300

As you can see, the values match, but the types don't.

The official SQL Server PHP Driver gives us the `PDO::SQLSRV_ATTR_FETCHES_NUMERIC_TYPE` attribute which should give us numeric casts. I just don't know how to enable them during testing and casting the expected values explicitly to integer feels "wrong" to me.

Calling `DB::connection('sqlsrv')->getPdo()->setAttribute(PDO::SQLSRV_ATTR_FETCHES_NUMERIC_TYPE, true)` in the `beforeEach` closure didn't help.

I've also faced a weird error regarding transactions, but that _might_ be because I'm still using msodbcsql17 instead of the current msodbcsql18.

This happened to me in the `one or more aggregates for a single type` test:
> [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Cannot roll back trans2. No transaction or savepoint of that name was found.

At least it is something in the current state:
![image](https://github.com/user-attachments/assets/abbbeb4d-8796-440f-adbb-b67669063c70)
