### PR TITLE
[1.x] Supports PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
         php: [8.1, 8.2, 8.3]
         laravel: [10, 11]
         stability: [prefer-lowest, prefer-stable]
+        include:
+          - php: 8.4
+            laravel: 11
+            stability: prefer-stable
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }} - MySQL 5.7
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,9 +59,13 @@ jobs:
       - name: Install redis-cli
         run: sudo apt-get install -qq redis-tools
 
-      - name: Install dependencies
+      - name: Require cachewerk/relay
         run: |
            composer require cachewerk/relay --no-interaction --no-update
+        if: matrix.php != 8.4
+          
+      - name: Install dependencies
+        run: |
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
@@ -118,9 +122,13 @@ jobs:
       - name: Install redis-cli
         run: sudo apt-get install -qq redis-tools
 
-      - name: Install dependencies
+      - name: Require cachewerk/relay
         run: |
            composer require cachewerk/relay --no-interaction --no-update
+        if: matrix.php != 8.4
+          
+      - name: Install dependencies
+        run: |
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
@@ -175,11 +183,14 @@ jobs:
       - name: Install redis-cli
         run: sudo apt-get install -qq redis-tools
 
+      - name: Require cachewerk/relay
+        run: |
+           composer require cachewerk/relay --no-interaction --no-update
+        if: matrix.php != 8.4
+
       - name: Install dependencies
         run: |
-           composer require "illuminate/contracts=^${{ matrix.laravel }}" --dev --no-update
-           composer require cachewerk/relay --no-interaction --no-update
-           composer update --prefer-dist --no-interaction --no-progress
+           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }} --with="illuminate/contracts=^${{ matrix.laravel }}"
 
       - name: Execute tests
         run: vendor/bin/pest -vvv
@@ -224,9 +235,13 @@ jobs:
       - name: Install redis-cli
         run: sudo apt-get install -qq redis-tools
 
-      - name: Install dependencies
+      - name: Require cachewerk/relay
         run: |
            composer require cachewerk/relay --no-interaction --no-update
+        if: matrix.php != 8.4
+
+      - name: Install dependencies
+        run: |
            composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -445,6 +445,7 @@ class DatabaseStorage implements Storage
      */
     public function values(string $type, ?array $keys = null): Collection
     {
+        /** @phpstan-ignore return.type */
         return $this->connection()
             ->table('pulse_values')
             ->select('timestamp', 'key', 'value')
@@ -529,6 +530,7 @@ class DatabaseStorage implements Storage
 
         $orderBy ??= $aggregates[0];
 
+        /** @phpstan-ignore return.type */
         return $this->connection()
             ->query()
             ->select([


### PR DESCRIPTION
Disable `cachewerk/relay` supports (missing `ext-relay` on PHP 8.4) and later add it back once `ext-relay` is available