### PR TITLE
[1.x] Format dates on graph updates

### DIFF
--- a/resources/views/livewire/servers.blade.php
+++ b/resources/views/livewire/servers.blade.php
@@ -195,7 +195,7 @@ Alpine.data('cpuChart', (config) => ({
                 return
             }
 
-            chart.data.labels = Object.keys(servers[config.slug].cpu)
+            chart.data.labels = Object.keys(servers[config.slug].cpu).map(formatDate)
             chart.data.datasets[0].data = Object.values(servers[config.slug].cpu)
             chart.update()
         })
@@ -275,7 +275,7 @@ Alpine.data('memoryChart', (config) => ({
                 return
             }
 
-            chart.data.labels = Object.keys(servers[config.slug].memory)
+            chart.data.labels = Object.keys(servers[config.slug].memory).map(formatDate)
             chart.data.datasets[0].data = Object.values(servers[config.slug].memory)
             chart.update()
         })


### PR DESCRIPTION
We recently started formatting dates based on the browsers timezone.

The dates are all formatted on page load, however with the special update handling for the graphs, the dates for the graphs returns to unformatted UTC time.

This PR ensures that new dates received via polling requests are formatted as expected.

The queues card is already handled, as it has formatting implemented in a `labels` function, which is already called on each update.