### PR TITLE
[1.x] Ensure run at is always returned to the front end in UTC

### DIFF
--- a/src/Livewire/Concerns/RemembersQueries.php
+++ b/src/Livewire/Concerns/RemembersQueries.php
@@ -20,7 +20,7 @@ trait RemembersQueries
     public function remember(callable $query, string $key = '', DateTimeInterface|DateInterval|Closure|int|null $ttl = 5): array
     {
         return App::make(CacheStoreResolver::class)->store()->remember('laravel:pulse:'.static::class.':'.$key.':'.$this->period, $ttl, function () use ($query) {
-            $start = CarbonImmutable::now()->toDateTimeString();
+            $start = CarbonImmutable::now('UTC')->toDateTimeString();
 
             [$value, $duration] = Benchmark::value(fn () => $query($this->periodAsInterval()));
 

--- a/tests/Feature/Livewire/RemembersQueriesTest.php
+++ b/tests/Feature/Livewire/RemembersQueriesTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Carbon;
+use Laravel\Pulse\Livewire\SlowQueries;
+use Livewire\Livewire;
+
+it('always returns the run at date in UTC time', function () {
+    date_default_timezone_set('Australia/Melbourne');
+    Carbon::setTestNow(Carbon::createFromFormat('Y-m-d H:i:s', '2000-01-01 13:00:00', 'UTC'));
+
+    Livewire::test(SlowQueries::class, ['lazy' => false, 'disableHighlighting' => true])
+        ->assertSeeHtml(<<<'HTML'
+            Run at: ${formatDate(&#039;2000-01-01 13:00:00&#039;)}
+            HTML);
+});
+

--- a/tests/Feature/Livewire/RemembersQueriesTest.php
+++ b/tests/Feature/Livewire/RemembersQueriesTest.php
@@ -13,4 +13,3 @@ it('always returns the run at date in UTC time', function () {
             Run at: ${formatDate(&#039;2000-01-01 13:00:00&#039;)}
             HTML);
 });
-


### PR DESCRIPTION
When setting a custom timezone within your application, the Run At date is being returned in the applications timezone instead of UTC.

The front end is always expected UTC dates, so we end up with dates that don't make sense.

<img width="410" alt="Screenshot 2024-11-29 at 11 05 17" src="https://github.com/user-attachments/assets/f8b56ed0-a46a-4d5d-8559-15b8ed92769a">
