### PR TITLE
[1.x] Prevent memory leak on `pulse:check` command when using Telescope

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,6 @@ parameters:
   paths:
     - src
   level: 8
+  ignoreErrors:
+    - "#Class Laravel\\\\Telescope\\\\Contracts\\\\EntriesRepository not found#"
+    - "#Call to static method store\\(\\) on an unknown class Laravel\\\\Telescope\\\\Telescope#"

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -83,7 +83,7 @@ class CheckCommand extends Command
      */
     protected function ensureTelescopeEntriesAreCollected(): void
     {
-        if ($this->laravel->bound(\Laravel\Telescope\Contracts\EntriesRepository::class)) {
+        if (! $this->laravel->bound(\Laravel\Telescope\Contracts\EntriesRepository::class)) {
             return;
         }
 

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -83,10 +83,8 @@ class CheckCommand extends Command
      */
     protected function ensureTelescopeEntriesAreCollected(): void
     {
-        if (! $this->laravel->bound(\Laravel\Telescope\Contracts\EntriesRepository::class)) {
-            return;
+        if ($this->laravel->bound(\Laravel\Telescope\Contracts\EntriesRepository::class)) {
+            \Laravel\Telescope\Telescope::store($this->laravel->make(\Laravel\Telescope\Contracts\EntriesRepository::class));
         }
-
-        \Laravel\Telescope\Telescope::store($this->laravel->make(\Laravel\Telescope\Contracts\EntriesRepository::class));
     }
 }

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -68,11 +68,25 @@ class CheckCommand extends Command
 
             $pulse->ingest();
 
+            $this->ensureTelescopeEntriesAreCollected();
+
             if ($isVapor || $this->option('once')) {
                 return self::SUCCESS;
             }
 
             Sleep::until($now->addSecond());
         }
+    }
+
+    /**
+     * Schedule Telescope to store entries if enabled.
+     */
+    protected function ensureTelescopeEntriesAreCollected(): void
+    {
+        if ($this->laravel->bound(\Laravel\Telescope\Contracts\EntriesRepository::class)) {
+            return;
+        }
+
+        \Laravel\Telescope\Telescope::store($this->laravel->make(\Laravel\Telescope\Contracts\EntriesRepository::class));
     }
 }


### PR DESCRIPTION
The `pulse:check` command causes a memory leak when using Telescope because the collected Telescope entries are kept in memory and never written to the database as the command never ends (supervisor daemon). This PR fixes that.

Similar to https://github.com/laravel/reverb/pull/151