### PR TITLE
[1.x] Use dedicated config value for trimming storage

### DIFF
--- a/config/pulse.php
+++ b/config/pulse.php
@@ -59,6 +59,10 @@ return [
     'storage' => [
         'driver' => env('PULSE_STORAGE_DRIVER', 'database'),
 
+        'trim' => [
+            'keep' => env('PULSE_STORAGE_KEEP', '7 days'),
+        ],
+
         'database' => [
             'connection' => env('PULSE_DB_CONNECTION'),
             'chunk' => 1000,

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -125,16 +125,24 @@ class DatabaseStorage implements Storage
     {
         $now = CarbonImmutable::now();
 
-        $keep = $this->config->get('pulse.ingest.trim.keep');
+        $keep = $this->config->get('pulse.storage.trim.keep') ?? '7 days';
+
+        $before = $now->subMilliseconds(
+            (int) CarbonInterval::fromString($keep)->totalMilliseconds
+        );
+
+        if ($now->subDays(7)->isAfter($before)) {
+            $before = $now->subDays(7);
+        }
 
         $this->connection()
             ->table('pulse_values')
-            ->where('timestamp', '<=', $now->sub($keep)->getTimestamp())
+            ->where('timestamp', '<=', $before->getTimestamp())
             ->delete();
 
         $this->connection()
             ->table('pulse_entries')
-            ->where('timestamp', '<=', $now->sub($keep)->getTimestamp())
+            ->where('timestamp', '<=', $before->getTimestamp())
             ->delete();
 
         $this->connection()
@@ -144,7 +152,7 @@ class DatabaseStorage implements Storage
             ->each(fn (int $period) => $this->connection()
                 ->table('pulse_aggregates')
                 ->where('period', $period)
-                ->where('bucket', '<=', $now->subMinutes($period)->getTimestamp())
+                ->where('bucket', '<=', max($now->subMinutes($period)->getTimestamp(), $before->getTimestamp()))
                 ->delete());
     }
 

--- a/tests/Feature/PulseTest.php
+++ b/tests/Feature/PulseTest.php
@@ -49,7 +49,7 @@ it('can trim records', function () {
 });
 
 it('can configure days of data to keep when trimming', function () {
-    Config::set('pulse.ingest.trim.keep', '30 days');
+    Config::set('pulse.storage.trim.keep', '30 days');
     App::instance(Storage::class, $storage = new StorageFake);
 
     Pulse::record('foo', 'delete', 0, now()->subMonth());

--- a/tests/StorageFake.php
+++ b/tests/StorageFake.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Illuminate\Support\Collection;
 use Laravel\Pulse\Contracts\Storage;
@@ -31,9 +32,15 @@ class StorageFake implements Storage
      */
     public function trim(): void
     {
-        $keep = config('pulse.ingest.trim.keep');
+        $now = CarbonImmutable::now();
 
-        $this->stored = $this->stored->reject(fn ($record) => $record->timestamp <= now()->sub($keep)->timestamp);
+        $keep = config('pulse.storage.trim.keep') ?? '7 days';
+
+        $before = $now->subMilliseconds(
+            (int) CarbonInterval::fromString($keep)->totalMilliseconds
+        );
+
+        $this->stored = $this->stored->reject(fn ($record) => $record->timestamp <= $before->timestamp);
     }
 
     /**


### PR DESCRIPTION
This is a follow up PR to https://github.com/laravel/pulse/pull/424/.

It introduces a dedicated trim config for the storage driver.

The recommended set up for Pulse installed on any high traffic application is using the Redis ingest and the Database storage. Having a dedicated config for storage allows you to have, say, 3 days of data in storage while maintaining only a couple of hours in the ingest.

Redis is likely to fall over if you tried to keep 3 days worth of data in it. The ingest trim is there as a safety mechanism in case the `pulse:work` command goes down.

So these two config values often serve a different purpose.

This PR also ensures that the configured storage trim duration is not greater than 7 days, which is the longest period Pulse supports.