### PR TITLE
[1.x] Prevent memory leak on `pulse:work` command when using Telescope

### DIFF
--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -55,11 +55,23 @@ class WorkCommand extends Command
                 $lastTrimmedStorageAt = $now;
             }
 
+            $this->ensureTelescopeEntriesAreCollected();
+
             if ($this->option('stop-when-empty')) {
                 return self::SUCCESS;
             }
 
             Sleep::for(1)->second();
+        }
+    }
+
+    /**
+     * Schedule Telescope to store entries if enabled.
+     */
+    protected function ensureTelescopeEntriesAreCollected(): void
+    {
+        if ($this->laravel->bound(\Laravel\Telescope\Contracts\EntriesRepository::class)) {
+            \Laravel\Telescope\Telescope::store($this->laravel->make(\Laravel\Telescope\Contracts\EntriesRepository::class));
         }
     }
 }


### PR DESCRIPTION
Same fix as https://github.com/laravel/pulse/pull/426

The `pulse:work` command causes a memory leak when using Telescope because the collected Telescope entries are kept in memory and never written to the database as the command never ends (supervisor daemon). This PR fixes that.