### PR TITLE
Allow system default of dark mode if theme value is unrecognized

### DIFF
--- a/resources/views/components/theme-switcher.blade.php
+++ b/resources/views/components/theme-switcher.blade.php
@@ -1,6 +1,6 @@
 <script>
 setDarkClass = () => {
-    if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    if (localStorage.theme === 'dark' || ((!('theme' in localStorage) || !['light', 'dark'].includes(localStorage.theme)) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
         document.documentElement.classList.add('dark')
     } else {
         document.documentElement.classList.remove('dark')


### PR DESCRIPTION
I ran into a theme issue while using pulse along side a filament admin panel.  Filament uses the same local storage key of "theme" but sets the theme to the value of "system" where as pulse expects the theme to be `undefined`.  This caused pulse to load the light theme by default rather than dark if the users system was set to dark mode. 

This PR adds a check to ignore any unexpected theme values when checking for the system preference of dark mode. 