### PR TITLE
[1.x] Fix: Keep select fields open

### DIFF
--- a/resources/views/livewire/exceptions.blade.php
+++ b/resources/views/livewire/exceptions.blade.php
@@ -10,6 +10,7 @@
         <x-slot:actions>
             <x-pulse::select
                 wire:model.live="orderBy"
+                id="select-exceptions-order-by"
                 label="Sort by"
                 :options="[
                     'count' => 'count',

--- a/resources/views/livewire/slow-jobs.blade.php
+++ b/resources/views/livewire/slow-jobs.blade.php
@@ -10,6 +10,7 @@
         <x-slot:actions>
             <x-pulse::select
                 wire:model.live="orderBy"
+                id="select-slow-jobs-order-by"
                 label="Sort by"
                 :options="[
                     'slowest' => 'slowest',

--- a/resources/views/livewire/slow-outgoing-requests.blade.php
+++ b/resources/views/livewire/slow-outgoing-requests.blade.php
@@ -24,6 +24,7 @@
 
             <x-pulse::select
                 wire:model.live="orderBy"
+                id="select-slow-outgoing-requests-order-by"
                 label="Sort by"
                 :options="[
                     'slowest' => 'slowest',

--- a/resources/views/livewire/slow-queries.blade.php
+++ b/resources/views/livewire/slow-queries.blade.php
@@ -28,6 +28,7 @@ if ($this->wantsHighlighting()) {
         <x-slot:actions>
             <x-pulse::select
                 wire:model.live="orderBy"
+                id="select-slow-queries-order-by"
                 label="Sort by"
                 :options="[
                     'slowest' => 'slowest',

--- a/resources/views/livewire/slow-requests.blade.php
+++ b/resources/views/livewire/slow-requests.blade.php
@@ -10,6 +10,7 @@
         <x-slot:actions>
             <x-pulse::select
                 wire:model.live="orderBy"
+                id="select-slow-requests-order-by"
                 label="Sort by"
                 :options="[
                     'slowest' => 'slowest',

--- a/resources/views/livewire/usage.blade.php
+++ b/resources/views/livewire/usage.blade.php
@@ -21,6 +21,7 @@
             @if (! $this->type)
                 <x-pulse::select
                     wire:model.live="usage"
+                    id="select-usage-by"
                     label="Top 10 users"
                     :options="[
                         'requests' => 'making requests',


### PR DESCRIPTION
Many pulse cards use the `<x-pulse::select />` component to sort or filter the results.
If the select component doesn't have an `id` attribute, it generates a random one on every rendering.
Because the `id` changes on every poll request (every 5 seconds), the DOM `<select />` element gets replaced and automatically closes the input field.
Passing a static `id` to every `<x-pulse::select />` component prevents DOM manipulations and keeps an active select field open.

![image](https://github.com/user-attachments/assets/6f0c5c10-9615-4d29-890e-c2537443a3ba)
