### PR TITLE
[1.x] Make `PulseMigration` compatible with Laravel v12.4: `public shouldRun()`

### DIFF
--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -22,7 +22,7 @@ class PulseMigration extends Migration
     /**
      * Determine if the migration should run.
      */
-    protected function shouldRun(): bool
+    public function shouldRun(): bool
     {
         if (in_array($this->driver(), ['mariadb', 'mysql', 'pgsql', 'sqlite'])) {
             return true;


### PR DESCRIPTION
In Laravel v12.4.0 laravel/framework#55011, the following method was added to `Illuminate\Database\Migrations\Migration`:

```php
    public function shouldRun(): bool
    {
        return true;
    }
```

so Laravel v12.4.0 breaks Pulse:

```
  In PulseMigration.php line 25:                                                                                                                                     
                                                                                                                                                                     
    Access level to Laravel\Pulse\Support\PulseMigration::shouldRun() must be public (as in class Illuminate\Database\Migrations\Migration)                              
```

This PR fixes it.