### PR TITLE
Make shouldRun Public to avoid error.

### DIFF
--- a/src/Support/PulseMigration.php
+++ b/src/Support/PulseMigration.php
@@ -22,7 +22,7 @@ class PulseMigration extends Migration
     /**
      * Determine if the migration should run.
      */
-    protected function shouldRun(): bool
+    public function shouldRun(): bool
     {
         if (in_array($this->driver(), ['mariadb', 'mysql', 'pgsql', 'sqlite'])) {
             return true;


### PR DESCRIPTION
A recent change to Laravel Framework is causing an error when running migrations for Pulse.

## Overview

A recent change in Laravel Framework introduced a public method `shouldRun` to the base Migration class. 

- https://github.com/laravel/framework/commit/b3dc56cdade3537d849302aa8278daa4330b1da6
- https://github.com/laravel/framework/blame/12.x/src/Illuminate/Database/Migrations/Migration.php#L36

This clashes somewhat with the method that the descendant class on pulse has except the method on the class in pulse is protected.

When I run my tests, phpunit complains 

````
  Output:                                                                                                          
  ================                                                                                                 
                                                                                                                   
  In PulseMigration.php line 25:                                                                                   
                                                                                                                   
                                                                                                                   
    Access level to Laravel\Pulse\Support\PulseMigration::shouldRun() must be public (as in class Illuminate\Data  
  base\Migrations\Migration)
````

There are two solutions to this, one is to change the visability to public to match the ancestor visibility or change the name of the method in pulse.  I have chosen to change the visibility but can change the name if desired.


