### PR TITLE
[1.x] Fix Dropdown Hover Effect

### DIFF
--- a/resources/views/components/theme-switcher.blade.php
+++ b/resources/views/components/theme-switcher.blade.php
@@ -45,7 +45,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', set
         <x-pulse::icons.moon class="hidden dark:block w-5 h-5" />
     </button>
 
-    <div x-show="menu" class="z-10 absolute origin-top-right right-0 bg-white dark:bg-gray-800 rounded-md ring-1 ring-gray-900/5 shadow-xl flex flex-col" style="display: none;" @click="menu = false">
+    <div x-show="menu" class="z-10 absolute origin-top-right right-0 bg-white dark:bg-gray-800 rounded-md ring-1 ring-gray-900/5 shadow-xl flex flex-col overflow-hidden" style="display: none;" @click="menu = false">
         <button class="flex items-center px-4 py-2 gap-3 hover:bg-gray-100 dark:hover:bg-gray-700" :class="theme === 'light' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'" @click="lightMode()">
             <x-pulse::icons.sun class="w-5 h-5" />
             Light


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fixes a visual issue where the first and last items in a dropdown menu appeared to lose their rounded corners on hover, making the edges look sharp.

The solution was to add the overflow-hidden class to the parent div containing rounded-md, ensuring that hover background effects from inner button elements do not visually override the container’s border radius.

Before:

![CleanShot 2025-05-13 at 22 31 21](https://github.com/user-attachments/assets/300e48d9-ca6d-472b-93f4-793b32c4e40d)

After:

![CleanShot 2025-05-13 at 22 32 00](https://github.com/user-attachments/assets/8c0f7155-b825-4bad-8c6b-0b2c226ae224)


