### PR TITLE
Remove `--with` flag from test runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }} --with="illuminate/contracts=^${{ matrix.laravel }}"
+           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
         run: vendor/bin/pest -vvv


### PR DESCRIPTION
Removing `--with="illuminate/contracts=^${{ matrix.laravel }}"` from the test runner as `pestphp/pest-plugin-laravel` doesn't support Laravel 12 just yet and none of the other items in the matrix had this flag.