### PR TITLE
Prevent usage of unpatched livewire version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "illuminate/routing": "^10.48.4|^11.0.8|^12.0",
         "illuminate/support": "^10.48.4|^11.0.8|^12.0",
         "illuminate/view": "^10.48.4|^11.0.8|^12.0",
-        "livewire/livewire": "^3.4.9",
+        "livewire/livewire": "^3.6.4",
         "symfony/console": "^6.0|^7.0",
         "nesbot/carbon": "^2.67|^3.0"
     },


### PR DESCRIPTION
I think it would be better if minimal version would be upgraded to the patched version of livewire. See https://github.com/advisories/GHSA-29cq-5w36-x7w3. But this can be a breaking change, so feel free to close if you think we shouldn't force people to use the patched version :)