### PR TITLE
Add reload command

### DIFF
--- a/src/PulseServiceProvider.php
+++ b/src/PulseServiceProvider.php
@@ -240,6 +240,10 @@ class PulseServiceProvider extends ServiceProvider
                 'Version' => InstalledVersions::getPrettyVersion('laravel/pulse'),
                 'Enabled' => AboutCommand::format(config('pulse.enabled'), console: fn ($value) => $value ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF'),
             ]);
+
+            if (method_exists($this, 'reloads')) {
+                $this->reloads('pulse:restart', 'pulse');
+            }
         }
     }
 }


### PR DESCRIPTION
Implements `reloads()` from https://github.com/laravel/framework/pull/57923

Added the check in console only, similar to where the commands are located, with a check to avoid bumping the version.