### PR TITLE
[PoC] Add Averages to "Slow XYZ" Recorders

### DIFF
--- a/resources/views/livewire/slow-requests.blade.php
+++ b/resources/views/livewire/slow-requests.blade.php
@@ -8,6 +8,19 @@
             <x-pulse::icons.arrows-left-right />
         </x-slot:icon>
         <x-slot:actions>
+            @php
+                $message = <<<MESSAGE
+                Count: X / Y → X requests above threshold out of Y total requests
+
+                Average: average request duration across all requests
+
+                Slowest: maximum request duration across all requests
+                MESSAGE;
+            @endphp
+            <button title="{{ $message }}" @click="alert(@js($message))">
+                <x-pulse::icons.information-circle class="w-5 h-5 stroke-gray-400 dark:stroke-gray-600" />
+            </button>
+
             <x-pulse::select
                 wire:model.live="orderBy"
                 id="select-slow-requests-order-by"
@@ -15,6 +28,8 @@
                 :options="[
                     'slowest' => 'slowest',
                     'count' => 'count',
+                    'average' => 'average',
+                    'total' => 'total',
                 ]"
                 @change="loading = true"
             />
@@ -31,12 +46,14 @@
                     <col width="100%" />
                     <col width="0%" />
                     <col width="0%" />
+                    <col width="0%" />
                 </colgroup>
                 <x-pulse::thead>
                     <tr>
                         <x-pulse::th>Method</x-pulse::th>
                         <x-pulse::th>Route</x-pulse::th>
                         <x-pulse::th class="text-right">Count</x-pulse::th>
+                        <x-pulse::th class="text-right">Average</x-pulse::th>
                         <x-pulse::th class="text-right">Slowest</x-pulse::th>
                     </tr>
                 </x-pulse::thead>
@@ -66,8 +83,11 @@
                                 @if ($config['sample_rate'] < 1)
                                     <span title="Sample rate: {{ $config['sample_rate'] }}, Raw value: {{ number_format($slowRequest->count) }}">~{{ number_format($slowRequest->count * (1 / $config['sample_rate'])) }}</span>
                                 @else
-                                    {{ number_format($slowRequest->count) }}
+                                    {{ number_format($slowRequest->count) }} / {{ number_format($slowRequest->total) }}
                                 @endif
+                            </x-pulse::td>
+                            <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                                <strong>{{ number_format($slowRequest->avg) }}</strong> ms
                             </x-pulse::td>
                             <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
                                 @if ($slowRequest->slowest === null)

--- a/src/Livewire/SlowRequests.php
+++ b/src/Livewire/SlowRequests.php
@@ -34,12 +34,15 @@ class SlowRequests extends Card
         [$slowRequests, $time, $runAt] = $this->remember(
             fn () => $this->aggregate(
                 'slow_request',
-                ['max', 'count'],
+                ['max', 'count', 'avg'],
                 match ($this->orderBy) {
                     'count' => 'count',
+                    'average' => 'avg',
+                    'total' => 'avg_count',
                     default => 'max',
                 },
-            )->map(function ($row) {
+            )
+            ->map(function ($row) {
                 [$method, $uri, $action] = json_decode($row->key, flags: JSON_THROW_ON_ERROR);
 
                 return (object) [
@@ -48,6 +51,8 @@ class SlowRequests extends Card
                     'action' => $action,
                     'count' => $row->count,
                     'slowest' => $row->max,
+                    'avg' => $row->avg,
+                    'total' => $row->avg_count,
                     'threshold' => $this->threshold($uri, SlowRequestsRecorder::class),
                 ];
             }),

--- a/src/Livewire/SlowRequests.php
+++ b/src/Livewire/SlowRequests.php
@@ -21,7 +21,7 @@ class SlowRequests extends Card
     /**
      * Ordering.
      *
-     * @var 'slowest'|'count'
+     * @var 'slowest'|'count'|'average'|'total'
      */
     #[Url(as: 'slow-requests')]
     public string $orderBy = 'slowest';

--- a/src/Recorders/SlowRequests.php
+++ b/src/Recorders/SlowRequests.php
@@ -54,19 +54,26 @@ class SlowRequests
 
         [$path, $via] = $this->resolveRoutePath($request);
 
-        if (
-            $this->shouldIgnore($path) ||
-            $this->underThreshold($duration = ((int) $startedAt->diffInMilliseconds()), $path)
-        ) {
+        if ($this->shouldIgnore($path)) {
             return;
         }
 
-        $this->pulse->record(
+        $duration = ((int) $startedAt->diffInMilliseconds());
+
+        // Record average and max duration for all requests.
+        $entry = $this->pulse->record(
             type: 'slow_request',
             key: json_encode([$request->method(), $path, $via], flags: JSON_THROW_ON_ERROR),
             value: $duration,
             timestamp: $startedAt,
-        )->max()->count();
+        )->avg()->max();
+
+        if ($this->underThreshold($duration, $path)) {
+            return;
+        }
+
+        // Record count of slow requests
+        $entry->count();
 
         if ($userId = $this->pulse->resolveAuthenticatedUserId()) {
             $this->pulse->record(

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -540,6 +540,10 @@ class DatabaseStorage implements Storage
 
         $orderBy ??= $aggregates[0];
 
+        if (in_array('avg', $aggregates)) {
+            $aggregates[] = 'avg_count';
+        }
+
         /** @phpstan-ignore return.type */
         return $this->connection()
             ->query()
@@ -561,6 +565,7 @@ class DatabaseStorage implements Storage
                         'max' => "max({$this->wrap('max')})",
                         'sum' => "sum({$this->wrap('sum')})",
                         'avg' => "avg({$this->wrap('avg')})",
+                        'avg_count' => "sum({$this->wrap('avg_count')})",
                     }." as {$this->wrap($aggregate)}");
                 }
 
@@ -581,6 +586,7 @@ class DatabaseStorage implements Storage
                             'max' => "max({$this->wrap('value')})",
                             'sum' => "sum({$this->wrap('value')})",
                             'avg' => "avg({$this->wrap('value')})",
+                            'avg_count' => 'count(*)',
                         }." as {$this->wrap($aggregate)}");
                     }
 
@@ -593,6 +599,10 @@ class DatabaseStorage implements Storage
 
                     // Buckets
                     foreach ($aggregates as $currentAggregate) {
+                        if ($currentAggregate === 'avg_count') {
+                            continue;
+                        }
+
                         $query->unionAll(function (Builder $query) use ($type, $aggregates, $currentAggregate, $period, $oldestBucket) {
                             $query->select('key_hash');
 
@@ -605,6 +615,8 @@ class DatabaseStorage implements Storage
                                         'sum' => "sum({$this->wrap('value')})",
                                         'avg' => "avg({$this->wrap('value')})",
                                     }." as {$this->wrap($aggregate)}");
+                                } elseif ($aggregate === 'avg_count' && $currentAggregate === 'avg') {
+                                    $query->selectRaw("sum({$this->wrap('count')}) as {$this->wrap('avg_count')}");
                                 } else {
                                     $query->selectRaw("null as {$this->wrap($aggregate)}");
                                 }

--- a/tests/Feature/Livewire/CacheTest.php
+++ b/tests/Feature/Livewire/CacheTest.php
@@ -58,8 +58,8 @@ it('does not round numbers up', function () {
     Pulse::ingest();
 
     Livewire::test(Cache::class, ['lazy' => false])
-        ->assertDontSeeHtml("100.00%\n")
-        ->assertSeeHtml("99.99%\n");
+        ->assertDontSeeHtml("100.00%" . PHP_EOL)
+        ->assertSeeHtml("99.99%" . PHP_EOL);
 });
 
 it('does not show decimals for round numbers', function () {
@@ -68,6 +68,6 @@ it('does not show decimals for round numbers', function () {
     Pulse::ingest();
 
     Livewire::test(Cache::class, ['lazy' => false])
-        ->assertDontSeeHtml("50.00%\n")
-        ->assertSeeHtml("50%\n");
+        ->assertDontSeeHtml("50.00%" . PHP_EOL)
+        ->assertSeeHtml("50%" . PHP_EOL);
 });

--- a/tests/Feature/Livewire/SlowRequestsTest.php
+++ b/tests/Feature/Livewire/SlowRequestsTest.php
@@ -17,26 +17,26 @@ it('renders slow requests', function () {
 
     // Add entries outside of the window.
     Carbon::setTestNow('2000-01-01 12:00:00');
-    Pulse::record('slow_request', $request1, 1)->max()->count();
-    Pulse::record('slow_request', $request2, 1)->max()->count();
+    Pulse::record('slow_request', $request1, 1)->avg()->max()->count();
+    Pulse::record('slow_request', $request2, 1)->avg()->max()->count();
 
     // Add entries to the "tail".
     Carbon::setTestNow('2000-01-01 12:00:01');
-    Pulse::record('slow_request', $request1, 1234)->max()->count();
-    Pulse::record('slow_request', $request1, 2468)->max()->count();
-    Pulse::record('slow_request', $request2, 1234)->max()->count();
+    Pulse::record('slow_request', $request1, 1234)->avg()->max()->count();
+    Pulse::record('slow_request', $request1, 2468)->avg()->max()->count();
+    Pulse::record('slow_request', $request2, 1234)->avg()->max()->count();
 
     // Add entries to the current buckets.
     Carbon::setTestNow('2000-01-01 13:00:00');
-    Pulse::record('slow_request', $request1, 1000)->max()->count();
-    Pulse::record('slow_request', $request1, 1000)->max()->count();
-    Pulse::record('slow_request', $request2, 1000)->max()->count();
+    Pulse::record('slow_request', $request1, 1000)->avg()->max()->count();
+    Pulse::record('slow_request', $request1, 1000)->avg()->max()->count();
+    Pulse::record('slow_request', $request2, 1000)->avg()->max()->count();
 
     Pulse::ingest();
 
     Livewire::test(SlowRequests::class, ['lazy' => false])
         ->assertViewHas('slowRequests', collect([
-            (object) ['method' => 'GET', 'uri' => '/users', 'action' => 'FooController@index', 'count' => 4, 'slowest' => 2468, 'threshold' => 1_000],
-            (object) ['method' => 'GET', 'uri' => '/users/{user}', 'action' => 'Closure', 'count' => 2, 'slowest' => 1234, 'threshold' => 1_000],
+            (object) ['method' => 'GET', 'uri' => '/users', 'action' => 'FooController@index', 'count' => 4, 'slowest' => 2468, 'threshold' => 1_000, 'avg' => 1425.5, 'total' => 4],
+            (object) ['method' => 'GET', 'uri' => '/users/{user}', 'action' => 'Closure', 'count' => 2, 'slowest' => 1234, 'threshold' => 1_000, 'avg' => 1117, 'total' => 2],
         ]));
 });

--- a/tests/Feature/Recorders/SlowRequestsTest.php
+++ b/tests/Feature/Recorders/SlowRequestsTest.php
@@ -33,69 +33,107 @@ it('captures requests over the threshold', function () {
     expect($entries[0]->value)->toBe(4000);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('type')->orderBy('period')->orderBy('aggregate')->get());
-    expect($aggregates)->toHaveCount(8);
+    expect($aggregates)->toHaveCount(12);
 
     expect($aggregates[0]->bucket)->toBe(946782240);
     expect($aggregates[0]->period)->toBe(60);
     expect($aggregates[0]->type)->toBe('slow_request');
-    expect($aggregates[0]->aggregate)->toBe('count');
+    expect($aggregates[0]->aggregate)->toBe('avg');
     expect($aggregates[0]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[0]->value)->toEqual(1);
+    expect($aggregates[0]->value)->toEqual(4000);
+    expect($aggregates[0]->count)->toEqual(1);
 
     expect($aggregates[1]->bucket)->toBe(946782240);
     expect($aggregates[1]->period)->toBe(60);
     expect($aggregates[1]->type)->toBe('slow_request');
-    expect($aggregates[1]->aggregate)->toBe('max');
+    expect($aggregates[1]->aggregate)->toBe('count');
     expect($aggregates[1]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[1]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[1]->value)->toEqual(4000);
+    expect($aggregates[1]->value)->toEqual(1);
 
-    expect($aggregates[2]->bucket)->toBe(946782000);
-    expect($aggregates[2]->period)->toBe(360);
+    expect($aggregates[2]->bucket)->toBe(946782240);
+    expect($aggregates[2]->period)->toBe(60);
     expect($aggregates[2]->type)->toBe('slow_request');
-    expect($aggregates[2]->aggregate)->toBe('count');
+    expect($aggregates[2]->aggregate)->toBe('max');
     expect($aggregates[2]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[2]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[2]->value)->toEqual(1);
+    expect($aggregates[2]->value)->toEqual(4000);
 
     expect($aggregates[3]->bucket)->toBe(946782000);
     expect($aggregates[3]->period)->toBe(360);
     expect($aggregates[3]->type)->toBe('slow_request');
-    expect($aggregates[3]->aggregate)->toBe('max');
+    expect($aggregates[3]->aggregate)->toBe('avg');
     expect($aggregates[3]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[3]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[3]->value)->toEqual(4000);
+    expect($aggregates[3]->count)->toEqual(1);
 
-    expect($aggregates[4]->bucket)->toBe(946781280);
-    expect($aggregates[4]->period)->toBe(1440);
+    expect($aggregates[4]->bucket)->toBe(946782000);
+    expect($aggregates[4]->period)->toBe(360);
     expect($aggregates[4]->type)->toBe('slow_request');
     expect($aggregates[4]->aggregate)->toBe('count');
     expect($aggregates[4]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[4]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[4]->value)->toEqual(1);
 
-    expect($aggregates[5]->bucket)->toBe(946781280);
-    expect($aggregates[5]->period)->toBe(1440);
+    expect($aggregates[5]->bucket)->toBe(946782000);
+    expect($aggregates[5]->period)->toBe(360);
     expect($aggregates[5]->type)->toBe('slow_request');
     expect($aggregates[5]->aggregate)->toBe('max');
     expect($aggregates[5]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[5]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
     expect($aggregates[5]->value)->toEqual(4000);
 
-    expect($aggregates[6]->period)->toBe(10080);
+    expect($aggregates[6]->bucket)->toBe(946781280);
+    expect($aggregates[6]->period)->toBe(1440);
     expect($aggregates[6]->type)->toBe('slow_request');
-    expect($aggregates[6]->aggregate)->toBe('count');
+    expect($aggregates[6]->aggregate)->toBe('avg');
     expect($aggregates[6]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[6]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[6]->value)->toEqual(1);
+    expect($aggregates[6]->value)->toEqual(4000);
+    expect($aggregates[6]->count)->toEqual(1);
 
-    expect($aggregates[7]->period)->toBe(10080);
+    expect($aggregates[7]->bucket)->toBe(946781280);
+    expect($aggregates[7]->period)->toBe(1440);
     expect($aggregates[7]->type)->toBe('slow_request');
-    expect($aggregates[7]->aggregate)->toBe('max');
+    expect($aggregates[7]->aggregate)->toBe('count');
     expect($aggregates[7]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
     expect($aggregates[7]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
-    expect($aggregates[7]->value)->toEqual(4000);
+    expect($aggregates[7]->value)->toEqual(1);
+
+    expect($aggregates[8]->bucket)->toBe(946781280);
+    expect($aggregates[8]->period)->toBe(1440);
+    expect($aggregates[8]->type)->toBe('slow_request');
+    expect($aggregates[8]->aggregate)->toBe('max');
+    expect($aggregates[8]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
+    expect($aggregates[8]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
+    expect($aggregates[8]->value)->toEqual(4000);
+
+    expect($aggregates[9]->bucket)->toBe(946774080);
+    expect($aggregates[9]->period)->toBe(10080);
+    expect($aggregates[9]->type)->toBe('slow_request');
+    expect($aggregates[9]->aggregate)->toBe('avg');
+    expect($aggregates[9]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
+    expect($aggregates[9]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
+    expect($aggregates[9]->value)->toEqual(4000);
+    expect($aggregates[9]->count)->toEqual(1);
+
+    expect($aggregates[10]->bucket)->toBe(946774080);
+    expect($aggregates[10]->period)->toBe(10080);
+    expect($aggregates[10]->type)->toBe('slow_request');
+    expect($aggregates[10]->aggregate)->toBe('count');
+    expect($aggregates[10]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
+    expect($aggregates[10]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
+    expect($aggregates[10]->value)->toEqual(1);
+
+    expect($aggregates[11]->bucket)->toBe(946774080);
+    expect($aggregates[11]->period)->toBe(10080);
+    expect($aggregates[11]->type)->toBe('slow_request');
+    expect($aggregates[11]->aggregate)->toBe('max');
+    expect($aggregates[11]->key)->toBe(json_encode(['GET', '/test-route', 'Closure']));
+    expect($aggregates[11]->key_hash)->toBe(keyHash(json_encode(['GET', '/test-route', 'Closure'])));
+    expect($aggregates[11]->value)->toEqual(4000);
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
@@ -122,11 +160,22 @@ it('can configure threshold per route', function () {
     get('default-threshold')->assertOk();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
-    expect($entries)->toHaveCount(1);
+    expect($entries)->toHaveCount(3);
+
     expect($entries[0]->type)->toBe('slow_request');
     expect($entries[0]->key)->toBe(json_encode(['GET', '/one-second-threshold', 'Closure']));
     expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/one-second-threshold', 'Closure'])));
     expect($entries[0]->value)->toBe(1000);
+
+    expect($entries[1]->type)->toBe('slow_request');
+    expect($entries[1]->key)->toBe(json_encode(['GET', '/two-second-threshold', 'Closure']));
+    expect($entries[1]->key_hash)->toBe(keyHash(json_encode(['GET', '/two-second-threshold', 'Closure'])));
+    expect($entries[1]->value)->toBe(1000);
+
+    expect($entries[2]->type)->toBe('slow_request');
+    expect($entries[2]->key)->toBe(json_encode(['GET', '/default-threshold', 'Closure']));
+    expect($entries[2]->key_hash)->toBe(keyHash(json_encode(['GET', '/default-threshold', 'Closure'])));
+    expect($entries[2]->value)->toBe(0);
 
     DB::table('pulse_entries')->delete();
 
@@ -136,15 +185,21 @@ it('can configure threshold per route', function () {
     get('default-threshold')->assertOk();
 
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->orderBy('key')->get());
-    expect($entries)->toHaveCount(2);
+    expect($entries)->toHaveCount(3);
     expect($entries[0]->type)->toBe('slow_request');
-    expect($entries[0]->key)->toBe(json_encode(['GET', '/one-second-threshold', 'Closure']));
-    expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/one-second-threshold', 'Closure'])));
-    expect($entries[0]->value)->toBe(2000);
+    expect($entries[0]->key)->toBe(json_encode(['GET', '/default-threshold', 'Closure']));
+    expect($entries[0]->key_hash)->toBe(keyHash(json_encode(['GET', '/default-threshold', 'Closure'])));
+    expect($entries[0]->value)->toBe(0);
+
     expect($entries[1]->type)->toBe('slow_request');
-    expect($entries[1]->key)->toBe(json_encode(['GET', '/two-second-threshold', 'Closure']));
-    expect($entries[1]->key_hash)->toBe(keyHash(json_encode(['GET', '/two-second-threshold', 'Closure'])));
+    expect($entries[1]->key)->toBe(json_encode(['GET', '/one-second-threshold', 'Closure']));
+    expect($entries[1]->key_hash)->toBe(keyHash(json_encode(['GET', '/one-second-threshold', 'Closure'])));
     expect($entries[1]->value)->toBe(2000);
+
+    expect($entries[2]->type)->toBe('slow_request');
+    expect($entries[2]->key)->toBe(json_encode(['GET', '/two-second-threshold', 'Closure']));
+    expect($entries[2]->key_hash)->toBe(keyHash(json_encode(['GET', '/two-second-threshold', 'Closure'])));
+    expect($entries[2]->value)->toBe(2000);
 });
 
 it('captures slow requests per user', function () {
@@ -212,7 +267,7 @@ it('captures requests equal to the threshold', function () {
     get('test-route');
 
     Pulse::ignore(fn () => expect(DB::table('pulse_entries')->get())->toHaveCount(1));
-    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->get())->toHaveCount(8));
+    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->get())->toHaveCount(12));
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
 
@@ -225,8 +280,8 @@ it('ignores requests under the threshold', function () {
 
     get('test-route');
 
-    Pulse::ignore(fn () => expect(DB::table('pulse_entries')->count())->toBe(0));
-    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->count())->toBe(0));
+    Pulse::ignore(fn () => expect(DB::table('pulse_entries')->count())->toBe(1));
+    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->count())->toBe(8));
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
 
@@ -320,71 +375,107 @@ it('captures the requests "via" route when using livewire', function () {
     expect($entries[0]->value)->toBe(4000);
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('type')->orderBy('period')->orderBy('aggregate')->get());
-    expect($aggregates)->toHaveCount(8);
+    expect($aggregates)->toHaveCount(12);
 
     expect($aggregates[0]->bucket)->toBe(946782240);
     expect($aggregates[0]->period)->toBe(60);
     expect($aggregates[0]->type)->toBe('slow_request');
-    expect($aggregates[0]->aggregate)->toBe('count');
+    expect($aggregates[0]->aggregate)->toBe('avg');
     expect($aggregates[0]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[0]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[0]->value)->toEqual(1);
+    expect($aggregates[0]->value)->toEqual(4000);
+    expect($aggregates[0]->count)->toEqual(1);
 
     expect($aggregates[1]->bucket)->toBe(946782240);
     expect($aggregates[1]->period)->toBe(60);
     expect($aggregates[1]->type)->toBe('slow_request');
-    expect($aggregates[1]->aggregate)->toBe('max');
+    expect($aggregates[1]->aggregate)->toBe('count');
     expect($aggregates[1]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[1]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[1]->value)->toEqual(4000);
+    expect($aggregates[1]->value)->toEqual(1);
 
-    expect($aggregates[2]->bucket)->toBe(946782000);
-    expect($aggregates[2]->period)->toBe(360);
+    expect($aggregates[2]->bucket)->toBe(946782240);
+    expect($aggregates[2]->period)->toBe(60);
     expect($aggregates[2]->type)->toBe('slow_request');
-    expect($aggregates[2]->aggregate)->toBe('count');
+    expect($aggregates[2]->aggregate)->toBe('max');
     expect($aggregates[2]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[2]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[2]->value)->toEqual(1);
+    expect($aggregates[2]->value)->toEqual(4000);
 
     expect($aggregates[3]->bucket)->toBe(946782000);
     expect($aggregates[3]->period)->toBe(360);
     expect($aggregates[3]->type)->toBe('slow_request');
-    expect($aggregates[3]->aggregate)->toBe('max');
+    expect($aggregates[3]->aggregate)->toBe('avg');
     expect($aggregates[3]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[3]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[3]->value)->toEqual(4000);
+    expect($aggregates[3]->count)->toEqual(1);
 
-    expect($aggregates[4]->bucket)->toBe(946781280);
-    expect($aggregates[4]->period)->toBe(1440);
+    expect($aggregates[4]->bucket)->toBe(946782000);
+    expect($aggregates[4]->period)->toBe(360);
     expect($aggregates[4]->type)->toBe('slow_request');
     expect($aggregates[4]->aggregate)->toBe('count');
     expect($aggregates[4]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[4]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[4]->value)->toEqual(1);
 
-    expect($aggregates[5]->bucket)->toBe(946781280);
-    expect($aggregates[5]->period)->toBe(1440);
+    expect($aggregates[5]->bucket)->toBe(946782000);
+    expect($aggregates[5]->period)->toBe(360);
     expect($aggregates[5]->type)->toBe('slow_request');
     expect($aggregates[5]->aggregate)->toBe('max');
     expect($aggregates[5]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[5]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
     expect($aggregates[5]->value)->toEqual(4000);
 
-    expect($aggregates[6]->bucket)->toBe(946774080);
-    expect($aggregates[6]->period)->toBe(10080);
+    expect($aggregates[6]->bucket)->toBe(946781280);
+    expect($aggregates[6]->period)->toBe(1440);
     expect($aggregates[6]->type)->toBe('slow_request');
-    expect($aggregates[6]->aggregate)->toBe('count');
+    expect($aggregates[6]->aggregate)->toBe('avg');
     expect($aggregates[6]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[6]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[6]->value)->toEqual(1);
+    expect($aggregates[6]->value)->toEqual(4000);
+    expect($aggregates[6]->count)->toEqual(1);
 
-    expect($aggregates[7]->bucket)->toBe(946774080);
-    expect($aggregates[7]->period)->toBe(10080);
+    expect($aggregates[7]->bucket)->toBe(946781280);
+    expect($aggregates[7]->period)->toBe(1440);
     expect($aggregates[7]->type)->toBe('slow_request');
-    expect($aggregates[7]->aggregate)->toBe('max');
+    expect($aggregates[7]->aggregate)->toBe('count');
     expect($aggregates[7]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
     expect($aggregates[7]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
-    expect($aggregates[7]->value)->toEqual(4000);
+    expect($aggregates[7]->value)->toEqual(1);
+
+    expect($aggregates[8]->bucket)->toBe(946781280);
+    expect($aggregates[8]->period)->toBe(1440);
+    expect($aggregates[8]->type)->toBe('slow_request');
+    expect($aggregates[8]->aggregate)->toBe('max');
+    expect($aggregates[8]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
+    expect($aggregates[8]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
+    expect($aggregates[8]->value)->toEqual(4000);
+
+    expect($aggregates[9]->bucket)->toBe(946774080);
+    expect($aggregates[9]->period)->toBe(10080);
+    expect($aggregates[9]->type)->toBe('slow_request');
+    expect($aggregates[9]->aggregate)->toBe('avg');
+    expect($aggregates[9]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
+    expect($aggregates[9]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
+    expect($aggregates[9]->value)->toEqual(4000);
+    expect($aggregates[9]->count)->toEqual(1);
+
+    expect($aggregates[10]->bucket)->toBe(946774080);
+    expect($aggregates[10]->period)->toBe(10080);
+    expect($aggregates[10]->type)->toBe('slow_request');
+    expect($aggregates[10]->aggregate)->toBe('count');
+    expect($aggregates[10]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
+    expect($aggregates[10]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
+    expect($aggregates[10]->value)->toEqual(1);
+
+    expect($aggregates[11]->bucket)->toBe(946774080);
+    expect($aggregates[11]->period)->toBe(10080);
+    expect($aggregates[11]->type)->toBe('slow_request');
+    expect($aggregates[11]->aggregate)->toBe('max');
+    expect($aggregates[11]->key)->toBe(json_encode(['POST', '/test-route', 'via /livewire/update']));
+    expect($aggregates[11]->key_hash)->toBe(keyHash(json_encode(['POST', '/test-route', 'via /livewire/update'])));
+    expect($aggregates[11]->value)->toEqual(4000);
 
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
@@ -414,7 +505,7 @@ it('handles routes with domains', function () {
 
     expect($entries[0]->key)->toBe(json_encode(['GET', '{account}.example.com/users', 'Closure']));
     expect($entries[1]->key)->toBe(json_encode(['GET', '/users', 'Closure']));
-    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->count())->toBe(16));
+    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->count())->toBe(24));
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
 
@@ -484,7 +575,7 @@ it('can sample at one', function () {
     get('test-route');
 
     Pulse::ignore(fn () => expect(DB::table('pulse_entries')->count())->toBe(10));
-    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->count())->toBe(8));
+    Pulse::ignore(fn () => expect(DB::table('pulse_aggregates')->count())->toBe(12));
     Pulse::ignore(fn () => expect(DB::table('pulse_values')->count())->toBe(0));
 });
 

--- a/tests/Feature/Recorders/UserRequestsTest.php
+++ b/tests/Feature/Recorders/UserRequestsTest.php
@@ -21,7 +21,7 @@ it('captures authenticated requests', function () {
 
     actingAs(User::make(['id' => '567']))->get('users');
 
-    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->get());
     expect($entries)->toHaveCount(1);
     expect($entries[0])->toHaveProperties([
         'timestamp' => 946782245,
@@ -29,7 +29,7 @@ it('captures authenticated requests', function () {
         'key' => '567',
         'value' => null,
     ]);
-    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->orderBy('period')->get());
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('type', 'user_request')->orderBy('period')->get());
     expect($aggregates)->toHaveCount(4);
     expect($aggregates)->toContainAggregateForAllPeriods(
         type: 'user_request',
@@ -44,7 +44,7 @@ it('ignores unauthenticated requests', function () {
 
     get('users');
 
-    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->get());
     expect($entries)->toHaveCount(0);
 });
 
@@ -53,7 +53,7 @@ it('captures the authenticated user if they login during the request', function 
 
     post('login');
 
-    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->get());
     expect($entries)->toHaveCount(1);
     expect($entries[0]->key)->toBe('567');
 });
@@ -63,7 +63,7 @@ it('captures the authenticated user if they logout during the request', function
 
     actingAs(User::make(['id' => '567']))->post('logout');
 
-    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->get());
     expect($entries)->toHaveCount(1);
     expect($entries[0]->key)->toBe('567');
 });
@@ -94,7 +94,7 @@ it('does not trigger an infinite loop when retrieving the authenticated user fro
 
     get('users');
 
-    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->get());
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->get());
     expect($entries)->toHaveCount(0);
 });
 
@@ -106,7 +106,7 @@ it('can ignore requests', function () {
 
     actingAs(User::make(['id' => '567']))->get('users');
 
-    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->count()))->toBe(0);
+    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->count()))->toBe(0);
 });
 
 it('ignores livewire update requests from an ignored path', function () {
@@ -129,7 +129,7 @@ it('ignores livewire update requests from an ignored path', function () {
             ],
         ]);
 
-    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->count()))->toBe(0);
+    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->count()))->toBe(0);
 });
 
 it('can sample', function () {
@@ -148,7 +148,7 @@ it('can sample', function () {
     get('users');
     get('users');
 
-    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->count()))->toEqualWithDelta(1, 4);
+    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->count()))->toEqualWithDelta(1, 4);
 });
 
 it('can sample at zero', function () {
@@ -167,7 +167,7 @@ it('can sample at zero', function () {
     get('users');
     get('users');
 
-    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->count()))->toBe(0);
+    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->count()))->toBe(0);
 });
 
 it('can sample at one', function () {
@@ -186,5 +186,5 @@ it('can sample at one', function () {
     get('users');
     get('users');
 
-    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->count()))->toBe(10);
+    expect(Pulse::ignore(fn () => DB::table('pulse_entries')->where('type', 'user_request')->count()))->toBe(10);
 });

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -328,8 +328,8 @@ test('one or more aggregates for a single type', function () {
     $results = Pulse::aggregate('slow_request', ['min', 'max', 'sum', 'avg', 'count'], CarbonInterval::hour());
 
     expect($results->all())->toEqual([
-        (object) ['key' => 'GET /bar', 'min' => 200, 'max' => 600, 'sum' => 2400, 'avg' => 400, 'count' => 6],
-        (object) ['key' => 'GET /foo', 'min' => 100, 'max' => 400, 'sum' => 2000, 'avg' => 250, 'count' => 8],
+        (object) ['key' => 'GET /bar', 'min' => 200, 'max' => 600, 'sum' => 2400, 'avg' => 400, 'count' => 6, 'avg_count' => 6],
+        (object) ['key' => 'GET /foo', 'min' => 100, 'max' => 400, 'sum' => 2000, 'avg' => 250, 'count' => 8, 'avg_count' => 8],
     ]);
 });
 


### PR DESCRIPTION
> [!IMPORTANT]
> This is a **proof-of-concept PR**, seeking opinions and evaluations from maintainers and contributors.

## What is this?
This is an extension to the already existing "Slow XYZ" recorders, e.g. the `SlowRequests` recorder. With the newly collected data, the Slow Request card now looks like this:

<img width="1812" height="978" alt="grafik" src="https://github.com/user-attachments/assets/88898ea7-8da8-4241-81e2-ff6d6f1e1961" />

## Disclaimer
> [!NOTE]
> The idea for this isn't new. It was first raised in #281. There was also a draft implementation in #284, from which I took some inspiration. For my own implementation, I came up with a solution for the main issues that were discussed in that first draft:
> 1. Which `average` value should be recorded – the **average of all requests** or the **average of requests above the threshold**?
> 2. How should the average value be recorded?
> 3. Bonus: How should the value be displayed in the UI to make its meaning easy to understand to the users?

## What has changed?
For now, this proof-of-concept implementation only extends the functionality of the `SlowRequests` recorder.
Here's what's changed:
- The recorder now calculates the `average` duration or **all requests**.
- The card now shows the total number of requests next to the `average` duration, making it more obvious what the “average” value represents.
- Adds `average` and `total` to the sorting options.
- Adds an info action `ⓘ` with a short explanation about the shown metrics.

## How has this been implemented?
The recorder now tracks all requests by default and calculates their `max` and `avg` durations. Additionally, if a request duration exceeds the configured threshold, it also increments the `count` metric.

For tracking the total number of requests, several approaches exist:
1. Record a new separate entry with a different type name (e.g. `slow-requests-total`). Then use the `->count()` aggregate.
2. Record a new separate entry with the same type name (`slow-requests`). Then (mis-)use the `->sum()` aggregate with a static value of `1`.
3. Don't record a separate entry. Use the existing `count` column of the `pulse_aggregates` table. This column contains the total count and is used for accurate average value calculation.

### Evaluation

I implemented, tested, and evaluated all three approaches.

<table>
<thead>
    <tr>
        <th>Approach</th>
        <th width="45%">Advantages</th>
        <th width="55%">Disadvantages</th>
    </tr>
</thead>
<tbody>
    <tr>
        <td>
            <pre lang="php">// Option 1:
Entry('slow-requests-total')
    ->count()</pre>
        </td>
        <td>
            <ul>
                <li>Separate entry type</li>
                <li>Easy to turn on/off</li>
            </ul>
        </td>
        <td>
            <ul>
                <li>Difficult to "merge" with slow entries</li>
                <li>Creates extra entries in database tables</li>
            </ul>
        </td>
    </tr>
    <tr>
        <td>
            <pre lang="php">// Option 2:
Entry('slow-requests')
    ->sum()</pre>
        </td>
        <td>
            <ul>
                <li>Easy to implement</li>
            </ul>
        </td>
        <td>
            <ul>
                <li>Feels "hacky"</li>
                <li>Creates duplicate entries with <code>value: 1</code> instead of <code>value: $duration</code></li>
            </ul>
        </td>
    </tr>
    <tr>
        <td>
            <pre lang="sql">-- Option 3:
pulse_aggregates.count</pre>
        </td>
        <td>
            <ul>
                <li>Easy to implement</li>
                <li>Uses existing data and logic</li>
                <li>Doesn't create duplicate entries</li>
            </ul>
        </td>
        <td>
            <ul>
                <li>A bit more difficult to turn on/off</li>
            </ul>
        </td>
    </tr>
</tbody>
</table>

### Decision
I chose **option 3**, as its advantages seem to outweigh its disadvantages the most. The implementation is straightforward and uses already-existing data. Also, it shouldn't break neither the ingesting nor the bucket logic. What do you think?

## To-Dos

- [ ] Apply the changes to all other "Slow XYZ" recorders as well:
    - [ ] `SlowJobs`
    - [ ] `SlowOutgoingRequests`
    - [ ] `SlowQueries`
- [ ] Add configuration options to enable/disable recording of average values
- [ ] Adjust existing feature tests
- [ ] Add new feature tests
- [ ] Anything else...?

## More Screenshots
<img width="348" height="266" alt="grafik" src="https://github.com/user-attachments/assets/532f2af7-c546-4a83-880e-283c5998f793" />

<img width="605" height="332" alt="grafik" src="https://github.com/user-attachments/assets/1f9ee888-0c13-4e75-8c64-5475a6362c64" />
