### PR TITLE
Remove deprecated backticks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - master
-      - '*.x'
+      - "*.x"
   pull_request:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   mysql:
@@ -68,12 +68,11 @@ jobs:
 
       - name: Require cachewerk/relay
         run: |
-           composer require cachewerk/relay --no-interaction --no-update
-        if: matrix.php != 8.5
-          
+          composer require cachewerk/relay --no-interaction --no-update
+
       - name: Install dependencies
         run: |
-           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
+          composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
         run: vendor/bin/pest -vvv
@@ -131,12 +130,11 @@ jobs:
 
       - name: Require cachewerk/relay
         run: |
-           composer require cachewerk/relay --no-interaction --no-update
-        if: matrix.php != 8.5
-          
+          composer require cachewerk/relay --no-interaction --no-update
+
       - name: Install dependencies
         run: |
-           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
+          composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
         run: vendor/bin/pest -vvv
@@ -192,12 +190,11 @@ jobs:
 
       - name: Require cachewerk/relay
         run: |
-           composer require cachewerk/relay --no-interaction --no-update
-        if: matrix.php != 8.5
+          composer require cachewerk/relay --no-interaction --no-update
 
       - name: Install dependencies
         run: |
-           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
+          composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
         run: vendor/bin/pest -vvv
@@ -244,12 +241,11 @@ jobs:
 
       - name: Require cachewerk/relay
         run: |
-           composer require cachewerk/relay --no-interaction --no-update
-        if: matrix.php != 8.5
+          composer require cachewerk/relay --no-interaction --no-update
 
       - name: Install dependencies
         run: |
-           composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
+          composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
       - name: Execute tests
         run: vendor/bin/pest -vvv

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "guzzlehttp/promises": "^1.0|^2.0",
         "doctrine/sql-formatter": "^1.4.1",
         "illuminate/auth": "^10.48.4|^11.0.8|^12.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
     "name": "laravel/pulse",
     "description": "Laravel Pulse is a real-time application performance monitoring tool and dashboard for your Laravel application.",
-    "keywords": ["laravel"],
+    "keywords": [
+        "laravel"
+    ],
     "homepage": "https://github.com/laravel/pulse",
     "license": "MIT",
     "support": {
@@ -15,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "guzzlehttp/promises": "^1.0|^2.0",
         "doctrine/sql-formatter": "^1.4.1",
         "illuminate/auth": "^10.48.4|^11.0.8|^12.0",
@@ -40,7 +42,7 @@
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^8.36|^9.15|^10.8",
         "pestphp/pest": "^2.0|^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^2.2",
+        "pestphp/pest-plugin-laravel": "^2.2|^3.0|^4.0",
         "phpstan/phpstan": "^1.12.21",
         "predis/predis": "^1.0|^2.0"
     },

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -72,7 +72,7 @@ class Servers
     public function record(SharedBeat $event): void
     {
         $this->throttle(15, $event, function ($event) {
-            $server = $this->config->get('pulse.recorders.' . self::class . '.server_name');
+            $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
             $slug = Str::slug($server);
 
             ['total' => $memoryTotal, 'used' => $memoryUsed] = $this->memory();
@@ -85,9 +85,9 @@ class Servers
                 'cpu' => $cpu,
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
-                'storage' => collect($this->config->get('pulse.recorders.' . self::class . '.directories')) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->filter(fn(string $directory) => ($this->pulse->rescue(fn() => disk_total_space($directory)) ?? false) !== false)
-                    ->map(fn(string $directory) => [
+                'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
+                    ->filter(fn (string $directory) => ($this->pulse->rescue(fn () => disk_total_space($directory)) ?? false) !== false)
+                    ->map(fn (string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB
                         'used' => intval(round($total - (disk_free_space($directory) / 1024 / 1024))), // MB
@@ -109,9 +109,9 @@ class Servers
         return match (PHP_OS_FAMILY) {
             'Darwin' => (int) shell_exec("top -l 1 | grep -E \"^CPU\" | tail -1 | awk '{ print $3 + $5 }'"),
             'Linux' => (int) shell_exec("top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'"),
-            'Windows' => (int) trim((string)shell_exec('wmic cpu get loadpercentage | more +1')),
+            'Windows' => (int) trim((string) shell_exec('wmic cpu get loadpercentage | more +1')),
             'BSD' => (int) shell_exec("top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'"),
-            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
     }
 
@@ -129,17 +129,17 @@ class Servers
         $memoryTotal = match (PHP_OS_FAMILY) {
             'Darwin' => intval(intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'")) / 1024 / 1024),
             'Linux' => intval(intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'")) / 1024),
-            'Windows' => intval(((int) trim((string)shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
+            'Windows' => intval(((int) trim((string) shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
             'BSD' => intval(intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'")) / 1024 / 1024),
-            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         $memoryUsed = match (PHP_OS_FAMILY) {
             'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'")) / 1024, // MB
-            'Windows' => $memoryTotal - intval(((int) trim((string)shell_exec('wmic OS get FreePhysicalMemory | more +1'))) / 1024), // MB
+            'Windows' => $memoryTotal - intval(((int) trim((string) shell_exec('wmic OS get FreePhysicalMemory | more +1'))) / 1024), // MB
             'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
-            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         return [

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -72,7 +72,7 @@ class Servers
     public function record(SharedBeat $event): void
     {
         $this->throttle(15, $event, function ($event) {
-            $server = $this->config->get('pulse.recorders.' . self::class . '.server_name');
+            $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
             $slug = Str::slug($server);
 
             ['total' => $memoryTotal, 'used' => $memoryUsed] = $this->memory();
@@ -85,9 +85,9 @@ class Servers
                 'cpu' => $cpu,
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
-                'storage' => collect($this->config->get('pulse.recorders.' . self::class . '.directories')) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->filter(fn(string $directory) => ($this->pulse->rescue(fn() => disk_total_space($directory)) ?? false) !== false)
-                    ->map(fn(string $directory) => [
+                'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
+                    ->filter(fn (string $directory) => ($this->pulse->rescue(fn () => disk_total_space($directory)) ?? false) !== false)
+                    ->map(fn (string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB
                         'used' => intval(round($total - (disk_free_space($directory) / 1024 / 1024))), // MB
@@ -109,9 +109,9 @@ class Servers
         return match (PHP_OS_FAMILY) {
             'Darwin' => (int) shell_exec("top -l 1 | grep -E \"^CPU\" | tail -1 | awk '{ print $3 + $5 }'"),
             'Linux' => (int) shell_exec("top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'"),
-            'Windows' => (int) trim(shell_exec("wmic cpu get loadpercentage | more +1")),
+            'Windows' => (int) trim(shell_exec('wmic cpu get loadpercentage | more +1')),
             'BSD' => (int) shell_exec("top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'"),
-            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
     }
 
@@ -129,17 +129,17 @@ class Servers
         $memoryTotal = match (PHP_OS_FAMILY) {
             'Darwin' => intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'") / 1024 / 1024),
             'Linux' => intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'") / 1024),
-            'Windows' => intval(((int) trim(shell_exec("wmic ComputerSystem get TotalPhysicalMemory | more +1"))) / 1024 / 1024),
+            'Windows' => intval(((int) trim(shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
             'BSD' => intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'") / 1024 / 1024),
-            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         $memoryUsed = match (PHP_OS_FAMILY) {
-            'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec("pagesize")) / 1024 / 1024), // MB
+            'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'") / 1024), // MB
-            'Windows' => $memoryTotal - intval(((int) trim(shell_exec("wmic OS get FreePhysicalMemory | more +1"))) / 1024), // MB
-            'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec("pagesize")) / 1024 / 1024), // MB
-            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
+            'Windows' => $memoryTotal - intval(((int) trim(shell_exec('wmic OS get FreePhysicalMemory | more +1'))) / 1024), // MB
+            'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
+            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
 
         return [

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -72,7 +72,7 @@ class Servers
     public function record(SharedBeat $event): void
     {
         $this->throttle(15, $event, function ($event) {
-            $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
+            $server = $this->config->get('pulse.recorders.' . self::class . '.server_name');
             $slug = Str::slug($server);
 
             ['total' => $memoryTotal, 'used' => $memoryUsed] = $this->memory();
@@ -85,9 +85,9 @@ class Servers
                 'cpu' => $cpu,
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
-                'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->filter(fn (string $directory) => ($this->pulse->rescue(fn () => disk_total_space($directory)) ?? false) !== false)
-                    ->map(fn (string $directory) => [
+                'storage' => collect($this->config->get('pulse.recorders.' . self::class . '.directories')) // @phpstan-ignore argument.templateType, argument.templateType
+                    ->filter(fn(string $directory) => ($this->pulse->rescue(fn() => disk_total_space($directory)) ?? false) !== false)
+                    ->map(fn(string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB
                         'used' => intval(round($total - (disk_free_space($directory) / 1024 / 1024))), // MB
@@ -107,11 +107,11 @@ class Servers
         }
 
         return match (PHP_OS_FAMILY) {
-            'Darwin' => (int) `top -l 1 | grep -E "^CPU" | tail -1 | awk '{ print $3 + $5 }'`,
-            'Linux' => (int) `top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'`,
-            'Windows' => (int) trim(`wmic cpu get loadpercentage | more +1`),
-            'BSD' => (int) `top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'`,
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            'Darwin' => (int) shell_exec("top -l 1 | grep -E \"^CPU\" | tail -1 | awk '{ print $3 + $5 }'"),
+            'Linux' => (int) shell_exec("top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'"),
+            'Windows' => (int) trim(shell_exec("wmic cpu get loadpercentage | more +1")),
+            'BSD' => (int) shell_exec("top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'"),
+            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
         };
     }
 
@@ -127,19 +127,19 @@ class Servers
         }
 
         $memoryTotal = match (PHP_OS_FAMILY) {
-            'Darwin' => intval(`sysctl hw.memsize | grep -Eo '[0-9]+'` / 1024 / 1024),
-            'Linux' => intval(`cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'` / 1024),
-            'Windows' => intval(((int) trim(`wmic ComputerSystem get TotalPhysicalMemory | more +1`)) / 1024 / 1024),
-            'BSD' => intval(`sysctl hw.physmem | grep -Eo '[0-9]+'` / 1024 / 1024),
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            'Darwin' => intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'") / 1024 / 1024),
+            'Linux' => intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'") / 1024),
+            'Windows' => intval(((int) trim(shell_exec("wmic ComputerSystem get TotalPhysicalMemory | more +1"))) / 1024 / 1024),
+            'BSD' => intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'") / 1024 / 1024),
+            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
         };
 
         $memoryUsed = match (PHP_OS_FAMILY) {
-            'Darwin' => $memoryTotal - intval(intval(`vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'`) * intval(`pagesize`) / 1024 / 1024), // MB
-            'Linux' => $memoryTotal - intval(`cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'` / 1024), // MB
-            'Windows' => $memoryTotal - intval(((int) trim(`wmic OS get FreePhysicalMemory | more +1`)) / 1024), // MB
-            'BSD' => intval(intval(`( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'`) * intval(`pagesize`) / 1024 / 1024), // MB
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec("pagesize")) / 1024 / 1024), // MB
+            'Linux' => $memoryTotal - intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'") / 1024), // MB
+            'Windows' => $memoryTotal - intval(((int) trim(shell_exec("wmic OS get FreePhysicalMemory | more +1"))) / 1024), // MB
+            'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec("pagesize")) / 1024 / 1024), // MB
+            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
         };
 
         return [

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -72,7 +72,7 @@ class Servers
     public function record(SharedBeat $event): void
     {
         $this->throttle(15, $event, function ($event) {
-            $server = $this->config->get('pulse.recorders.'.self::class.'.server_name');
+            $server = $this->config->get('pulse.recorders.' . self::class . '.server_name');
             $slug = Str::slug($server);
 
             ['total' => $memoryTotal, 'used' => $memoryUsed] = $this->memory();
@@ -85,9 +85,9 @@ class Servers
                 'cpu' => $cpu,
                 'memory_used' => $memoryUsed,
                 'memory_total' => $memoryTotal,
-                'storage' => collect($this->config->get('pulse.recorders.'.self::class.'.directories')) // @phpstan-ignore argument.templateType, argument.templateType
-                    ->filter(fn (string $directory) => ($this->pulse->rescue(fn () => disk_total_space($directory)) ?? false) !== false)
-                    ->map(fn (string $directory) => [
+                'storage' => collect($this->config->get('pulse.recorders.' . self::class . '.directories')) // @phpstan-ignore argument.templateType, argument.templateType
+                    ->filter(fn(string $directory) => ($this->pulse->rescue(fn() => disk_total_space($directory)) ?? false) !== false)
+                    ->map(fn(string $directory) => [
                         'directory' => $directory,
                         'total' => $total = intval(round(disk_total_space($directory) / 1024 / 1024)), // MB
                         'used' => intval(round($total - (disk_free_space($directory) / 1024 / 1024))), // MB
@@ -109,9 +109,9 @@ class Servers
         return match (PHP_OS_FAMILY) {
             'Darwin' => (int) shell_exec("top -l 1 | grep -E \"^CPU\" | tail -1 | awk '{ print $3 + $5 }'"),
             'Linux' => (int) shell_exec("top -bn1 | grep -E '^(%Cpu|CPU)' | awk '{ print $2 + $4 }'"),
-            'Windows' => (int) trim(shell_exec('wmic cpu get loadpercentage | more +1')),
+            'Windows' => (int) trim((string)shell_exec('wmic cpu get loadpercentage | more +1')),
             'BSD' => (int) shell_exec("top -b -d 2| grep 'CPU: ' | tail -1 | awk '{print$10}' | grep -Eo '[0-9]+\.[0-9]+' | awk '{ print 100 - $1 }'"),
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
         };
     }
 
@@ -127,19 +127,19 @@ class Servers
         }
 
         $memoryTotal = match (PHP_OS_FAMILY) {
-            'Darwin' => intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'") / 1024 / 1024),
-            'Linux' => intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'") / 1024),
-            'Windows' => intval(((int) trim(shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
-            'BSD' => intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'") / 1024 / 1024),
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            'Darwin' => intval(intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'")) / 1024 / 1024),
+            'Linux' => intval(intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'")) / 1024),
+            'Windows' => intval(((int) trim((string)shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
+            'BSD' => intval(intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'")) / 1024 / 1024),
+            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
         };
 
         $memoryUsed = match (PHP_OS_FAMILY) {
             'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
-            'Linux' => $memoryTotal - intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'") / 1024), // MB
-            'Windows' => $memoryTotal - intval(((int) trim(shell_exec('wmic OS get FreePhysicalMemory | more +1'))) / 1024), // MB
+            'Linux' => $memoryTotal - intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'")) / 1024, // MB
+            'Windows' => $memoryTotal - intval(((int) trim((string)shell_exec('wmic OS get FreePhysicalMemory | more +1'))) / 1024), // MB
             'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
-            default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
+            default => throw new RuntimeException('The pulse:check command does not currently support ' . PHP_OS_FAMILY),
         };
 
         return [

--- a/src/Users.php
+++ b/src/Users.php
@@ -50,7 +50,7 @@ class Users implements ResolvesUsers
             // @phpstan-ignore staticMethod.notFound
             $this->resolvedUsers = $model::findMany($keys);
         } else {
-            $this->resolvedUsers = $keys->map(fn($key) => $provider->retrieveById($key));
+            $this->resolvedUsers = $keys->map(fn ($key) => $provider->retrieveById($key));
         }
 
         return $this;
@@ -63,7 +63,7 @@ class Users implements ResolvesUsers
      */
     public function find(int|string|null $key): object
     {
-        $user = $this->resolvedUsers->first(fn($user) => $this->key($user) == $key);
+        $user = $this->resolvedUsers->first(fn ($user) => $this->key($user) == $key);
 
         if ($this->fieldResolver !== null && $user !== null) {
             return (object) ($this->fieldResolver)($user);

--- a/src/Users.php
+++ b/src/Users.php
@@ -47,9 +47,10 @@ class Users implements ResolvesUsers
         if ($provider instanceof EloquentUserProvider) {
             $model = $provider->getModel();
 
+            // @phpstan-ignore staticMethod.notFound
             $this->resolvedUsers = $model::findMany($keys);
         } else {
-            $this->resolvedUsers = $keys->map(fn ($key) => $provider->retrieveById($key));
+            $this->resolvedUsers = $keys->map(fn($key) => $provider->retrieveById($key));
         }
 
         return $this;
@@ -62,7 +63,7 @@ class Users implements ResolvesUsers
      */
     public function find(int|string|null $key): object
     {
-        $user = $this->resolvedUsers->first(fn ($user) => $this->key($user) == $key);
+        $user = $this->resolvedUsers->first(fn($user) => $this->key($user) == $key);
 
         if ($this->fieldResolver !== null && $user !== null) {
             return (object) ($this->fieldResolver)($user);


### PR DESCRIPTION
This PR modernizes command execution syntax by replacing deprecated backticks with shell_exec in preparation for PHP 8.5. [More info](https://www.php.net/releases/8.5/en.php#:~:text=The%20backtick%20operator%20as%20an%20alias%20for%20shell%5Fexec%28%29%20has%20been%20deprecated).
Due to the [function being available since PHP 4](https://www.php.net/manual/en/function.shell-exec.php) there is no backward incompatibility.

Changes:

- Compatibility: Added support for `^3.0` and `^4.0` in `pestphp/pest-plugin-laravel` to support PHP `8.5` targets.
- Refactor: Replaced backtick execution operators with shell_exec in `src/Recorders/Servers.php`.