### PR TITLE
Add sortBy option to Server Livewire card for customizable sorting

### DIFF
--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -19,6 +19,7 @@ class Servers extends Card
     use InteractsWithTime;
 
     public int|string|null $ignoreAfter = null;
+    public string|null $sortBy = 'name';
 
     /**
      * Render the component.
@@ -49,7 +50,7 @@ class Servers extends Card
                     ];
                 })
                 ->filter()
-                ->sortBy('name');
+                ->sortBy($this->sortBy);
         });
 
         if (Livewire::isLivewireRequest()) {

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -20,6 +20,7 @@ class Servers extends Card
 
     public int|string|null $ignoreAfter = null;
     public string|null $sortBy = 'name';
+    public string|null $sortDirection = 'asc';
 
     /**
      * Render the component.
@@ -50,7 +51,7 @@ class Servers extends Card
                     ];
                 })
                 ->filter()
-                ->sortBy($this->sortBy);
+                ->sortBy($this->sortBy, descending: $this->sortDirection === 'desc');
         });
 
         if (Livewire::isLivewireRequest()) {

--- a/src/Livewire/Servers.php
+++ b/src/Livewire/Servers.php
@@ -19,8 +19,8 @@ class Servers extends Card
     use InteractsWithTime;
 
     public int|string|null $ignoreAfter = null;
-    public string|null $sortBy = 'name';
-    public string|null $sortDirection = 'asc';
+    public string $sortBy = 'name';
+    public string $sortDirection = 'asc';
 
     /**
      * Render the component.

--- a/tests/Feature/Livewire/ServersTest.php
+++ b/tests/Feature/Livewire/ServersTest.php
@@ -88,6 +88,34 @@ it('sorts by server name', function () {
         ->assertSeeInOrder(['A Web', 'B Web', 'C Web']);
 });
 
+it('sorts descending', function () {
+    $data = [
+        'memory_used' => 1234,
+        'memory_total' => 2468,
+        'cpu' => 99,
+        'storage' => [
+            ['directory' => '/', 'used' => 123, 'total' => 456],
+        ],
+    ];
+    Pulse::set('system', 'b-web', json_encode([
+        'name' => 'B Web',
+        ...$data,
+    ]), now()->subSeconds(2));
+    Pulse::set('system', 'a-web', json_encode([
+        'name' => 'A Web',
+        ...$data,
+    ]), now()->subSeconds(3));
+    Pulse::set('system', 'c-web', json_encode([
+        'name' => 'C Web',
+        ...$data,
+    ]), now()->subSeconds(1));
+
+    Pulse::ingest();
+
+    Livewire::test(Servers::class, ['lazy' => false, 'sortDirection' => 'desc'])
+        ->assertSeeInOrder(['C Web', 'B Web', 'A Web']);
+});
+
 it('sorts by updated at', function () {
     $data = [
         'memory_used' => 1234,

--- a/tests/Feature/Livewire/ServersTest.php
+++ b/tests/Feature/Livewire/ServersTest.php
@@ -88,6 +88,34 @@ it('sorts by server name', function () {
         ->assertSeeInOrder(['A Web', 'B Web', 'C Web']);
 });
 
+it('sorts by updated at', function () {
+    $data = [
+        'memory_used' => 1234,
+        'memory_total' => 2468,
+        'cpu' => 99,
+        'storage' => [
+            ['directory' => '/', 'used' => 123, 'total' => 456],
+        ],
+    ];
+    Pulse::set('system', 'b-web', json_encode([
+        'name' => 'B Web',
+        ...$data,
+    ]), now()->subSeconds(2));
+    Pulse::set('system', 'a-web', json_encode([
+        'name' => 'A Web',
+        ...$data,
+    ]), now()->subSeconds(3));
+    Pulse::set('system', 'c-web', json_encode([
+        'name' => 'C Web',
+        ...$data,
+    ]), now()->subSeconds(1));
+
+    Pulse::ingest();
+
+    Livewire::test(Servers::class, ['lazy' => false, 'sortBy' => 'updated_at'])
+        ->assertSeeInOrder(['A Web', 'B Web', 'C Web']);
+});
+
 it('can ignore servers that have stopped reporting', function ($ignoreAfter, $see, $dontSee) {
     Carbon::setTestNow(now()->startOfSecond());
 


### PR DESCRIPTION
Being able to sort the servers card by `updated_at` is useful for Kubernetes deployments, where there will be many destroyed and active pods mixed. 

The usage would be like this:
`<livewire:pulse.servers cols="full" ignore-after="3 hours" sort-by="updated_at"/>`

Since this is a new parameter, it should be backward compatible. I've also written a test.

BTW, thanks for this awesome package!