### PR TITLE
MySQL 9.6 lack of md5() support fix

### DIFF
--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -34,14 +34,14 @@ return new class extends PulseMigration
         });
 
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('
+            DB::connection($this->getConnection())->unprepared('
                 CREATE TRIGGER pulse_values_before_insert
                 BEFORE INSERT ON pulse_values
                 FOR EACH ROW
                 SET NEW.key_hash = UNHEX(MD5(NEW.key))
             ');
 
-            DB::unprepared('
+            DB::connection($this->getConnection())->unprepared('
                 CREATE TRIGGER pulse_values_before_update
                 BEFORE UPDATE ON pulse_values
                 FOR EACH ROW
@@ -68,14 +68,14 @@ return new class extends PulseMigration
         });
 
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('
+            DB::connection($this->getConnection())->unprepared('
                 CREATE TRIGGER pulse_entries_before_insert
                 BEFORE INSERT ON pulse_entries
                 FOR EACH ROW
                 SET NEW.key_hash = UNHEX(MD5(NEW.key))
             ');
 
-            DB::unprepared('
+            DB::connection($this->getConnection())->unprepared('
                 CREATE TRIGGER pulse_entries_before_update
                 BEFORE UPDATE ON pulse_entries
                 FOR EACH ROW
@@ -105,14 +105,14 @@ return new class extends PulseMigration
         });
 
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('
+            DB::connection($this->getConnection())->unprepared('
                 CREATE TRIGGER pulse_aggregates_before_insert
                 BEFORE INSERT ON pulse_aggregates
                 FOR EACH ROW
                 SET NEW.key_hash = UNHEX(MD5(NEW.key))
             ');
 
-            DB::unprepared('
+            DB::connection($this->getConnection())->unprepared('
                 CREATE TRIGGER pulse_aggregates_before_update
                 BEFORE UPDATE ON pulse_aggregates
                 FOR EACH ROW
@@ -127,12 +127,12 @@ return new class extends PulseMigration
     public function down(): void
     {
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_insert');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_update');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_insert');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_update');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_insert');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_update');
+            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_values_before_insert');
+            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_values_before_update');
+            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_insert');
+            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_update');
+            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_insert');
+            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_update');
         }
 
         Schema::dropIfExists('pulse_values');

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Pulse\Support\PulseMigration;
 
@@ -22,7 +21,7 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -33,29 +32,13 @@ return new class extends PulseMigration
             $table->unique(['type', 'key_hash']); // For data integrity and upserts...
         });
 
-        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('
-                CREATE TRIGGER pulse_values_before_insert
-                BEFORE INSERT ON pulse_values
-                FOR EACH ROW
-                SET NEW.key_hash = UNHEX(MD5(NEW.key))
-            ');
-
-            DB::unprepared('
-                CREATE TRIGGER pulse_values_before_update
-                BEFORE UPDATE ON pulse_values
-                FOR EACH ROW
-                SET NEW.key_hash = UNHEX(MD5(NEW.key))
-            ');
-        }
-
         Schema::create('pulse_entries', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -67,22 +50,6 @@ return new class extends PulseMigration
             $table->index(['timestamp', 'type', 'key_hash', 'value']); // For aggregate queries...
         });
 
-        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('
-                CREATE TRIGGER pulse_entries_before_insert
-                BEFORE INSERT ON pulse_entries
-                FOR EACH ROW
-                SET NEW.key_hash = UNHEX(MD5(NEW.key))
-            ');
-
-            DB::unprepared('
-                CREATE TRIGGER pulse_entries_before_update
-                BEFORE UPDATE ON pulse_entries
-                FOR EACH ROW
-                SET NEW.key_hash = UNHEX(MD5(NEW.key))
-            ');
-        }
-
         Schema::create('pulse_aggregates', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('bucket');
@@ -90,7 +57,7 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -103,22 +70,6 @@ return new class extends PulseMigration
             $table->index('type'); // For purging...
             $table->index(['period', 'type', 'aggregate', 'bucket']); // For aggregate queries...
         });
-
-        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('
-                CREATE TRIGGER pulse_aggregates_before_insert
-                BEFORE INSERT ON pulse_aggregates
-                FOR EACH ROW
-                SET NEW.key_hash = UNHEX(MD5(NEW.key))
-            ');
-
-            DB::unprepared('
-                CREATE TRIGGER pulse_aggregates_before_update
-                BEFORE UPDATE ON pulse_aggregates
-                FOR EACH ROW
-                SET NEW.key_hash = UNHEX(MD5(NEW.key))
-            ');
-        }
     }
 
     /**
@@ -126,15 +77,6 @@ return new class extends PulseMigration
      */
     public function down(): void
     {
-        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_insert');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_update');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_insert');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_update');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_insert');
-            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_update');
-        }
-
         Schema::dropIfExists('pulse_values');
         Schema::dropIfExists('pulse_entries');
         Schema::dropIfExists('pulse_aggregates');

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Pulse\Support\PulseMigration;
 
@@ -21,7 +22,7 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -32,13 +33,29 @@ return new class extends PulseMigration
             $table->unique(['type', 'key_hash']); // For data integrity and upserts...
         });
 
+        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
+            DB::unprepared('
+                CREATE TRIGGER pulse_values_before_insert
+                BEFORE INSERT ON pulse_values
+                FOR EACH ROW
+                SET NEW.key_hash = UNHEX(MD5(NEW.key))
+            ');
+
+            DB::unprepared('
+                CREATE TRIGGER pulse_values_before_update
+                BEFORE UPDATE ON pulse_values
+                FOR EACH ROW
+                SET NEW.key_hash = UNHEX(MD5(NEW.key))
+            ');
+        }
+
         Schema::create('pulse_entries', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('timestamp');
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -50,6 +67,22 @@ return new class extends PulseMigration
             $table->index(['timestamp', 'type', 'key_hash', 'value']); // For aggregate queries...
         });
 
+        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
+            DB::unprepared('
+                CREATE TRIGGER pulse_entries_before_insert
+                BEFORE INSERT ON pulse_entries
+                FOR EACH ROW
+                SET NEW.key_hash = UNHEX(MD5(NEW.key))
+            ');
+
+            DB::unprepared('
+                CREATE TRIGGER pulse_entries_before_update
+                BEFORE UPDATE ON pulse_entries
+                FOR EACH ROW
+                SET NEW.key_hash = UNHEX(MD5(NEW.key))
+            ');
+        }
+
         Schema::create('pulse_aggregates', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('bucket');
@@ -57,7 +90,7 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -70,6 +103,22 @@ return new class extends PulseMigration
             $table->index('type'); // For purging...
             $table->index(['period', 'type', 'aggregate', 'bucket']); // For aggregate queries...
         });
+
+        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
+            DB::unprepared('
+                CREATE TRIGGER pulse_aggregates_before_insert
+                BEFORE INSERT ON pulse_aggregates
+                FOR EACH ROW
+                SET NEW.key_hash = UNHEX(MD5(NEW.key))
+            ');
+
+            DB::unprepared('
+                CREATE TRIGGER pulse_aggregates_before_update
+                BEFORE UPDATE ON pulse_aggregates
+                FOR EACH ROW
+                SET NEW.key_hash = UNHEX(MD5(NEW.key))
+            ');
+        }
     }
 
     /**
@@ -77,6 +126,15 @@ return new class extends PulseMigration
      */
     public function down(): void
     {
+        if (in_array($this->driver(), ['mariadb', 'mysql'])) {
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_update');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_update');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_update');
+        }
+
         Schema::dropIfExists('pulse_values');
         Schema::dropIfExists('pulse_entries');
         Schema::dropIfExists('pulse_aggregates');

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -34,14 +34,14 @@ return new class extends PulseMigration
         });
 
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::connection($this->getConnection())->unprepared('
+            DB::unprepared('
                 CREATE TRIGGER pulse_values_before_insert
                 BEFORE INSERT ON pulse_values
                 FOR EACH ROW
                 SET NEW.key_hash = UNHEX(MD5(NEW.key))
             ');
 
-            DB::connection($this->getConnection())->unprepared('
+            DB::unprepared('
                 CREATE TRIGGER pulse_values_before_update
                 BEFORE UPDATE ON pulse_values
                 FOR EACH ROW
@@ -68,14 +68,14 @@ return new class extends PulseMigration
         });
 
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::connection($this->getConnection())->unprepared('
+            DB::unprepared('
                 CREATE TRIGGER pulse_entries_before_insert
                 BEFORE INSERT ON pulse_entries
                 FOR EACH ROW
                 SET NEW.key_hash = UNHEX(MD5(NEW.key))
             ');
 
-            DB::connection($this->getConnection())->unprepared('
+            DB::unprepared('
                 CREATE TRIGGER pulse_entries_before_update
                 BEFORE UPDATE ON pulse_entries
                 FOR EACH ROW
@@ -105,14 +105,14 @@ return new class extends PulseMigration
         });
 
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::connection($this->getConnection())->unprepared('
+            DB::unprepared('
                 CREATE TRIGGER pulse_aggregates_before_insert
                 BEFORE INSERT ON pulse_aggregates
                 FOR EACH ROW
                 SET NEW.key_hash = UNHEX(MD5(NEW.key))
             ');
 
-            DB::connection($this->getConnection())->unprepared('
+            DB::unprepared('
                 CREATE TRIGGER pulse_aggregates_before_update
                 BEFORE UPDATE ON pulse_aggregates
                 FOR EACH ROW
@@ -127,12 +127,12 @@ return new class extends PulseMigration
     public function down(): void
     {
         if (in_array($this->driver(), ['mariadb', 'mysql'])) {
-            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_values_before_insert');
-            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_values_before_update');
-            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_insert');
-            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_update');
-            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_insert');
-            DB::connection($this->getConnection())->unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_update');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_values_before_update');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_entries_before_update');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS pulse_aggregates_before_update');
         }
 
         Schema::dropIfExists('pulse_values');

--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -21,8 +21,8 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
-                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
+                'pgsql' => $table->uuid('key_hash'),
                 'sqlite' => $table->string('key_hash'),
             };
             $table->mediumText('value');
@@ -38,8 +38,8 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
-                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
+                'pgsql' => $table->uuid('key_hash'),
                 'sqlite' => $table->string('key_hash'),
             };
             $table->bigInteger('value')->nullable();
@@ -57,8 +57,8 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
-                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary'),
+                'pgsql' => $table->uuid('key_hash'),
                 'sqlite' => $table->string('key_hash'),
             };
             $table->string('aggregate');

--- a/database/migrations/2026_02_13_000001_remove_generated_key_hash_from_pulse_tables.php
+++ b/database/migrations/2026_02_13_000001_remove_generated_key_hash_from_pulse_tables.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pulse\Support\PulseMigration;
+
+return new class extends PulseMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! $this->shouldRun()) {
+            return;
+        }
+
+        foreach (['pulse_values', 'pulse_entries', 'pulse_aggregates'] as $tableName) {
+            Schema::table($tableName, function (Blueprint $table) {
+                match ($this->driver()) {
+                    'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->change(),
+                    'pgsql' => $table->uuid('key_hash')->change(),
+                    'sqlite' => $table->string('key_hash')->change(),
+                };
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! $this->shouldRun()) {
+            return;
+        }
+
+        foreach (['pulse_values', 'pulse_entries', 'pulse_aggregates'] as $tableName) {
+            Schema::table($tableName, function (Blueprint $table) {
+                match ($this->driver()) {
+                    'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))')->change(),
+                    'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid')->change(),
+                    'sqlite' => $table->string('key_hash')->change(),
+                };
+            });
+        }
+    }
+};

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -49,14 +49,10 @@ class DatabaseStorage implements Storage
 
         $entryChunks = $entries
             ->reject->isOnlyBuckets()
-            ->when(
-                $this->requiresManualKeyHash(),
-                fn ($entries) => $entries->map(fn ($entry) => [
-                    ...($attributes = $entry->attributes()),
-                    'key_hash' => md5($attributes['key']),
-                ]),
-                fn ($entries) => $entries->map->attributes()
-            )
+            ->map(fn ($entry) => [
+                ...($attributes = $entry->attributes()),
+                'key_hash' => $this->keyHash($attributes['key']),
+            ])
             ->chunk($this->config->get('pulse.storage.database.chunk'));
 
         [$counts, $minimums, $maximums, $sums, $averages] = array_values($entries
@@ -86,14 +82,10 @@ class DatabaseStorage implements Storage
 
         $valueChunks = $this // @phpstan-ignore method.nonObject
             ->collapseValues($values)
-            ->when(
-                $this->requiresManualKeyHash(),
-                fn ($values) => $values->map(fn ($value) => [
-                    ...($attributes = $value->attributes()),
-                    'key_hash' => md5($attributes['key']),
-                ]),
-                fn ($values) => $values->map->attributes()
-            )
+            ->map(fn ($value) => [
+                ...($attributes = $value->attributes()),
+                'key_hash' => $this->keyHash($attributes['key']),
+            ])
             ->chunk($this->config->get('pulse.storage.database.chunk'));
 
         $this->connection()->transaction(function () use ($entryChunks, $countChunks, $minimumChunks, $maximumChunks, $sumChunks, $averageChunks, $valueChunks) {
@@ -416,9 +408,7 @@ class DatabaseStorage implements Storage
                         'key' => $entry->key,
                     ], $entry);
 
-                    if ($this->requiresManualKeyHash()) {
-                        $aggregates[$key]['key_hash'] = md5($entry->key);
-                    }
+                    $aggregates[$key]['key_hash'] = $this->keyHash($entry->key);
                 } else {
                     $aggregates[$key] = $callback($aggregates[$key], $entry);
                 }
@@ -828,10 +818,22 @@ class DatabaseStorage implements Storage
     }
 
     /**
-     * Determine whether a manually generated key hash is required.
+     * Hash a key using the current database driver's storage format.
      */
-    protected function requiresManualKeyHash(): bool
+    protected function keyHash(string $key): string
     {
-        return $this->connection()->getDriverName() === 'sqlite';
+        return match ($this->connection()->getDriverName()) {
+            'mariadb', 'mysql' => hex2bin(md5($key)),
+            'pgsql' => sprintf(
+                '%s-%s-%s-%s-%s',
+                substr($hash = md5($key), 0, 8),
+                substr($hash, 8, 4),
+                substr($hash, 12, 4),
+                substr($hash, 16, 4),
+                substr($hash, 20, 12)
+            ),
+            'sqlite' => md5($key),
+            default => throw new RuntimeException('Unsupported database driver.'),
+        };
     }
 }

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -823,7 +823,7 @@ class DatabaseStorage implements Storage
     protected function keyHash(string $key): string
     {
         return match ($this->connection()->getDriverName()) {
-            'mariadb', 'mysql' => hex2bin(md5($key)),
+            'mariadb', 'mysql' => pack('H*', md5($key)),
             'pgsql' => sprintf(
                 '%s-%s-%s-%s-%s',
                 substr($hash = md5($key), 0, 8),

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -80,7 +80,7 @@ class DatabaseStorage implements Storage
         $averageChunks = $this->preaggregateAverages(collect($averages)) // @phpstan-ignore argument.templateType, argument.templateType
             ->chunk($this->config->get('pulse.storage.database.chunk'));
 
-        $valueChunks = $this // @phpstan-ignore method.nonObject
+        $valueChunks = $this
             ->collapseValues($values)
             ->map(fn ($value) => [
                 ...($attributes = $value->attributes()),
@@ -105,7 +105,7 @@ class DatabaseStorage implements Storage
 
             $valueChunks->each(fn ($chunk) => $this->connection()
                 ->table('pulse_values')
-                ->upsert($chunk->all(), ['type', 'key_hash'], ['timestamp', 'value']) // @phpstan-ignore method.nonObject
+                ->upsert($chunk->all(), ['type', 'key_hash'], ['timestamp', 'value'])
             );
         }, 3);
     }

--- a/tests/Feature/Storage/DatabaseStorageTest.php
+++ b/tests/Feature/Storage/DatabaseStorageTest.php
@@ -138,13 +138,8 @@ it('combines duplicate count aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
-        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
-    } else {
-        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
-    }
+    expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+    expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(3);
@@ -168,13 +163,8 @@ it('combines duplicate min aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
-        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
-    } else {
-        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
-    }
+    expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+    expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(100);
@@ -198,13 +188,8 @@ it('combines duplicate max aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
-        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
-    } else {
-        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
-    }
+    expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+    expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(300);
@@ -228,13 +213,8 @@ it('combines duplicate sum aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
-        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
-    } else {
-        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 6 * 4); // 2 entries, 6 columns each, 4 periods
-    }
+    expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+    expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->pluck('value', 'key'));
     expect($aggregates['key1'])->toEqual(600);
@@ -258,13 +238,8 @@ it('combines duplicate average aggregates before upserting', function () {
     expect($queries)->toHaveCount(2);
     expect($queries[0]->sql)->toContain('pulse_entries');
     expect($queries[1]->sql)->toContain('pulse_aggregates');
-    if (DB::connection()->getDriverName() === 'sqlite') {
-        expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 8 * 4); // 2 entries, 8 columns each, 4 periods
-    } else {
-        expect($queries[0]->bindings)->toHaveCount(4 * 4); // 4 entries, 4 columns each
-        expect($queries[1]->bindings)->toHaveCount(2 * 7 * 4); // 2 entries, 7 columns each, 4 periods
-    }
+    expect($queries[0]->bindings)->toHaveCount(4 * 5); // 4 entries, 5 columns each
+    expect($queries[1]->bindings)->toHaveCount(2 * 8 * 4); // 2 entries, 8 columns each, 4 periods
 
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->where('period', 60)->orderBy('key')->get())->keyBy('key');
     expect($aggregates['key1']->value)->toEqual(200);


### PR DESCRIPTION
MySQL 9.6 has restricted the use of `md5()` function in generated columns, causing the Pulse [migration to fail](https://github.com/laravel/pulse/issues/476) with:

```
General error: 3763 Expression of generated column 'key_hash' contains a disallowed function: md5.
```

I suggest to replace generated virtual columns approach with triggers that are fully supported in MySQL/MariaDB since version 5.