### PR TITLE
Restrict unserialize in RedisIngest

### DIFF
--- a/src/Ingests/RedisIngest.php
+++ b/src/Ingests/RedisIngest.php
@@ -92,7 +92,7 @@ class RedisIngest implements Ingest
             $keys = $entries->keys();
 
             $storage->store(
-                $entries->map(fn (array $payload): Entry|Value => unserialize($payload['data']))->values()
+                $entries->map(fn (array $payload): Entry|Value => unserialize($payload['data'], ['allowed_classes' => [Entry::class, Value::class]]))->values()
             );
 
             $this->connection()->xdel($this->stream, $keys);


### PR DESCRIPTION
Adds allowed_classes to unserialize() in RedisIngest::digest() to prevent PHP object injection if Redis is compromised.