### PR TITLE
Use @js() for directory path in servers blade

### DIFF
--- a/resources/views/livewire/servers.blade.php
+++ b/resources/views/livewire/servers.blade.php
@@ -105,7 +105,7 @@ $rows = ! empty($rows) ? $rows : 1;
                                 wire:ignore
                                 x-data="storageChart({
                                     slug: '{{ $slug }}',
-                                    directory: '{{ $storage->directory }}',
+                                    directory: @js($storage->directory),
                                     used: {{ $storage->used }},
                                     total: {{ $storage->total }},
                                 })"

--- a/src/Ingests/RedisIngest.php
+++ b/src/Ingests/RedisIngest.php
@@ -92,7 +92,7 @@ class RedisIngest implements Ingest
             $keys = $entries->keys();
 
             $storage->store(
-                $entries->map(fn (array $payload): Entry|Value => unserialize($payload['data']))->values()
+                $entries->map(fn (array $payload): Entry|Value => unserialize($payload['data'], ['allowed_classes' => [Entry::class, Value::class]]))->values()
             );
 
             $this->connection()->xdel($this->stream, $keys);


### PR DESCRIPTION
Replaces `'{{ $storage->directory }}'` with `@js($storage->directory)` to properly escape directory paths for JavaScript context inside Alpine.js x-data attributes.