### PR TITLE
Use @js() for directory path in servers blade

### DIFF
--- a/resources/views/livewire/servers.blade.php
+++ b/resources/views/livewire/servers.blade.php
@@ -105,7 +105,7 @@ $rows = ! empty($rows) ? $rows : 1;
                                 wire:ignore
                                 x-data="storageChart({
                                     slug: '{{ $slug }}',
-                                    directory: '{{ $storage->directory }}',
+                                    directory: @js($storage->directory),
                                     used: {{ $storage->used }},
                                     total: {{ $storage->total }},
                                 })"


### PR DESCRIPTION
Replaces `'{{ $storage->directory }}'` with `@js($storage->directory)` to properly escape directory paths for JavaScript context inside Alpine.js x-data attributes.