### PR TITLE
Skip debug_backtrace for queries under slow threshold

### DIFF
--- a/src/Recorders/SlowQueries.php
+++ b/src/Recorders/SlowQueries.php
@@ -37,11 +37,12 @@ class SlowQueries
      */
     public function record(QueryExecuted $event): void
     {
-        [$timestampMs, $duration, $sql, $location] = [
+        $duration = (int) $event->time;
+        $sql = $event->sql;
+
+        [$timestampMs, $location] = [
             CarbonImmutable::now()->getTimestampMs(),
-            (int) $event->time,
-            $event->sql,
-            $this->config->get('pulse.recorders.'.self::class.'.location')
+            $this->config->get('pulse.recorders.'.self::class.'.location') && ! $this->underThreshold($duration, $sql)
                 ? $this->resolveLocation()
                 : null,
         ];


### PR DESCRIPTION
Currently `resolveLocation()` calls `debug_backtrace()` for every `QueryExecuted` event regardless of whether the query exceeds the slow threshold. Since the vast majority of queries are fast and will be discarded, this adds unnecessary overhead. This change checks the threshold before capturing the backtrace, skipping it entirely for queries that won't be recorded.