### PR TITLE
fix: Handle unsupported drivers in Pulse migrations

### DIFF
--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -24,6 +24,7 @@ return new class extends PulseMigration
                 'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
+                default => throw new \RuntimeException('Unsupported database driver: ' . $this->driver()),
             };
             $table->mediumText('value');
 
@@ -41,6 +42,7 @@ return new class extends PulseMigration
                 'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
+                default => throw new \RuntimeException('Unsupported database driver: ' . $this->driver()),
             };
             $table->bigInteger('value')->nullable();
 
@@ -60,6 +62,7 @@ return new class extends PulseMigration
                 'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
+                default => throw new \RuntimeException('Unsupported database driver: ' . $this->driver()),
             };
             $table->string('aggregate');
             $table->decimal('value', 20, 2);


### PR DESCRIPTION
This PR adds a default case to the match expression in migrations to ensure all potential string values from `$this->driver()` are handled. This prevents potential `UnhandledMatchError`