### PR TITLE
Allow `Pulse::record()` and `Pulse::set()` to accept enums

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -19,6 +19,9 @@ use Laravel\Pulse\Contracts\Storage;
 use Laravel\Pulse\Events\ExceptionReported;
 use RuntimeException;
 use Throwable;
+use UnitEnum;
+
+use function Illuminate\Support\enum_value;
 
 /**
  * @internal
@@ -142,8 +145,8 @@ class Pulse
      * Record an entry.
      */
     public function record(
-        string $type,
-        string $key,
+        UnitEnum|string $type,
+        UnitEnum|string $key,
         ?int $value = null,
         DateTimeInterface|int|null $timestamp = null,
     ): Entry {
@@ -151,8 +154,8 @@ class Pulse
 
         $entry = new Entry(
             timestamp: $timestamp instanceof DateTimeInterface ? $timestamp->getTimestamp() : $timestamp,
-            type: $type,
-            key: $key,
+            type: enum_value($type),
+            key: enum_value($key),
             value: $value,
         );
 
@@ -169,8 +172,8 @@ class Pulse
      * Record a value.
      */
     public function set(
-        string $type,
-        string $key,
+        UnitEnum|string $type,
+        UnitEnum|string $key,
         string $value,
         DateTimeInterface|int|null $timestamp = null,
     ): Value {
@@ -178,8 +181,8 @@ class Pulse
 
         $value = new Value(
             timestamp: $timestamp instanceof DateTimeInterface ? $timestamp->getTimestamp() : $timestamp,
-            type: $type,
-            key: $key,
+            type: enum_value($type),
+            key: enum_value($key),
             value: $value,
         );
 

--- a/tests/Feature/PulseTest.php
+++ b/tests/Feature/PulseTest.php
@@ -269,7 +269,74 @@ it('handles logout events when there is no user', function () {
     expect(true)->toBe(true);
 });
 
+it('accepts backed enums for record type', function () {
+    App::instance(Storage::class, $storage = new StorageFake);
+
+    Pulse::record(PulseTestBackedEnum::Slow, 'key', 100);
+    Pulse::ingest();
+
+    expect($storage->stored)->toHaveCount(1);
+    expect($storage->stored[0])->toBeInstanceOf(Entry::class);
+    expect($storage->stored[0]->type)->toBe('slow_request');
+});
+
+it('accepts backed enums for record key', function () {
+    App::instance(Storage::class, $storage = new StorageFake);
+
+    Pulse::record('type', PulseTestBackedEnum::Slow, 100);
+    Pulse::ingest();
+
+    expect($storage->stored)->toHaveCount(1);
+    expect($storage->stored[0])->toBeInstanceOf(Entry::class);
+    expect($storage->stored[0]->key)->toBe('slow_request');
+});
+
+it('accepts backed enums for set type', function () {
+    App::instance(Storage::class, $storage = new StorageFake);
+
+    Pulse::set(PulseTestBackedEnum::Slow, 'key', 'value');
+    Pulse::ingest();
+
+    expect($storage->stored)->toHaveCount(1);
+    expect($storage->stored[0])->toBeInstanceOf(Value::class);
+    expect($storage->stored[0]->type)->toBe('slow_request');
+});
+
+it('accepts backed enums for set key', function () {
+    App::instance(Storage::class, $storage = new StorageFake);
+
+    Pulse::set('type', PulseTestBackedEnum::Slow, 'value');
+    Pulse::ingest();
+
+    expect($storage->stored)->toHaveCount(1);
+    expect($storage->stored[0])->toBeInstanceOf(Value::class);
+    expect($storage->stored[0]->key)->toBe('slow_request');
+});
+
+it('accepts unit enums for record type', function () {
+    App::instance(Storage::class, $storage = new StorageFake);
+
+    Pulse::record(PulseTestUnitEnum::Slow, 'key', 100);
+    Pulse::ingest();
+
+    expect($storage->stored)->toHaveCount(1);
+    expect($storage->stored[0])->toBeInstanceOf(Entry::class);
+    expect($storage->stored[0]->type)->toBe('Slow');
+});
+
 class MyTestMiddleware
 {
     //
+}
+
+enum PulseTestBackedEnum: string
+{
+    case Slow = 'slow_request';
+    case Fast = 'fast_request';
+}
+
+enum PulseTestUnitEnum
+{
+    case Slow;
+    case Fast;
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds enum support to `Pulse::record()` and `Pulse::set()`. Both $type and $key now accept BackedEnum, UnitEnum, or string, so you can pass enums directly instead of manually extracting ->value or ->name.
