### PR TITLE
Replace md5() with sha2() for MySQL 9.6 compatibility

### DIFF
--- a/database/migrations/2023_06_07_000001_create_pulse_tables.php
+++ b/database/migrations/2023_06_07_000001_create_pulse_tables.php
@@ -21,7 +21,8 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(substr(sha2(`key`, 256), 1, 32))'),
+                'mariadb' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -38,7 +39,8 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(substr(sha2(`key`, 256), 1, 32))'),
+                'mariadb' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };
@@ -57,7 +59,8 @@ return new class extends PulseMigration
             $table->string('type');
             $table->mediumText('key');
             match ($this->driver()) {
-                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(substr(sha2(`key`, 256), 1, 32))'),
+                'mariadb' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
                 'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
                 'sqlite' => $table->string('key_hash'),
             };

--- a/database/migrations/2026_03_19_000001_update_pulse_tables_key_hash_for_mysql_96.php
+++ b/database/migrations/2026_03_19_000001_update_pulse_tables_key_hash_for_mysql_96.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pulse\Support\PulseMigration;
+
+return new class extends PulseMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! $this->shouldRun()) {
+            return;
+        }
+
+        if ($this->driver() !== 'mysql') {
+            return;
+        }
+
+        if (Schema::hasTable('pulse_values')) {
+            Schema::table('pulse_values', function (Blueprint $table) {
+                $table->dropUnique(['type', 'key_hash']);
+                $table->dropColumn('key_hash');
+            });
+
+            Schema::table('pulse_values', function (Blueprint $table) {
+                $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(substr(sha2(`key`, 256), 1, 32))')->after('key');
+                $table->unique(['type', 'key_hash']);
+            });
+        }
+
+        if (Schema::hasTable('pulse_entries')) {
+            Schema::table('pulse_entries', function (Blueprint $table) {
+                $table->dropIndex(['key_hash']);
+                $table->dropIndex(['timestamp', 'type', 'key_hash', 'value']);
+                $table->dropColumn('key_hash');
+            });
+
+            Schema::table('pulse_entries', function (Blueprint $table) {
+                $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(substr(sha2(`key`, 256), 1, 32))')->after('key');
+                $table->index('key_hash');
+                $table->index(['timestamp', 'type', 'key_hash', 'value']);
+            });
+        }
+
+        if (Schema::hasTable('pulse_aggregates')) {
+            Schema::table('pulse_aggregates', function (Blueprint $table) {
+                $table->dropUnique(['bucket', 'period', 'type', 'aggregate', 'key_hash']);
+                $table->dropColumn('key_hash');
+            });
+
+            Schema::table('pulse_aggregates', function (Blueprint $table) {
+                $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(substr(sha2(`key`, 256), 1, 32))')->after('key');
+                $table->unique(['bucket', 'period', 'type', 'aggregate', 'key_hash']);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if ($this->driver() !== 'mysql') {
+            return;
+        }
+
+        if (Schema::hasTable('pulse_values')) {
+            Schema::table('pulse_values', function (Blueprint $table) {
+                $table->dropUnique(['type', 'key_hash']);
+                $table->dropColumn('key_hash');
+            });
+
+            Schema::table('pulse_values', function (Blueprint $table) {
+                $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))')->after('key');
+                $table->unique(['type', 'key_hash']);
+            });
+        }
+
+        if (Schema::hasTable('pulse_entries')) {
+            Schema::table('pulse_entries', function (Blueprint $table) {
+                $table->dropIndex(['key_hash']);
+                $table->dropIndex(['timestamp', 'type', 'key_hash', 'value']);
+                $table->dropColumn('key_hash');
+            });
+
+            Schema::table('pulse_entries', function (Blueprint $table) {
+                $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))')->after('key');
+                $table->index('key_hash');
+                $table->index(['timestamp', 'type', 'key_hash', 'value']);
+            });
+        }
+
+        if (Schema::hasTable('pulse_aggregates')) {
+            Schema::table('pulse_aggregates', function (Blueprint $table) {
+                $table->dropUnique(['bucket', 'period', 'type', 'aggregate', 'key_hash']);
+                $table->dropColumn('key_hash');
+            });
+
+            Schema::table('pulse_aggregates', function (Blueprint $table) {
+                $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))')->after('key');
+                $table->unique(['bucket', 'period', 'type', 'aggregate', 'key_hash']);
+            });
+        }
+    }
+};

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -104,7 +104,8 @@ expect()->extend('toContainAggregateForAllPeriods', function (string|array $type
 function keyHash(string $string): string
 {
     return match (DB::connection()->getDriverName()) {
-        'mariadb', 'mysql' => hex2bin(md5($string)),
+        'mysql' => hex2bin(substr(hash('sha256', $string), 0, 32)),
+        'mariadb' => hex2bin(md5($string)),
         'pgsql' => Uuid::fromString(md5($string)),
         'sqlite' => md5($string),
     };


### PR DESCRIPTION
## Summary

- MySQL 9.6 removed `md5()` from the default installation, breaking Pulse's virtual `key_hash` columns that use `unhex(md5())`. This replaces `md5()` with `sha2()` (which remains available in MySQL 9.6) for the MySQL driver, while keeping `md5()` for MariaDB where it is still supported.
- Includes a new migration to update the virtual column expression and rebuild indexes for existing installations.
- Updates the test helper `keyHash()` to use the matching `sha256` hash for MySQL.

Fixes #476

## Test plan

- [ ] Run migration on MySQL 9.6 instance and verify tables are created without errors
- [ ] Run the update migration on an existing MySQL installation with Pulse tables
- [ ] Verify that existing Pulse data remains queryable after migration (virtual column recomputes automatically)
- [ ] Run the existing test suite against MySQL, MariaDB, PostgreSQL, and SQLite
- [ ] Verify `down()` migration correctly reverts to `md5()` on pre-9.6 MySQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)