### PR TITLE
Sanitize entry keys to prevent invalid UTF-8 errors

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -155,7 +155,7 @@ class Pulse
         $entry = new Entry(
             timestamp: $timestamp instanceof DateTimeInterface ? $timestamp->getTimestamp() : $timestamp,
             type: enum_value($type),
-            key: enum_value($key),
+            key: $this->sanitizeKey(enum_value($key)),
             value: $value,
         );
 
@@ -182,7 +182,7 @@ class Pulse
         $value = new Value(
             timestamp: $timestamp instanceof DateTimeInterface ? $timestamp->getTimestamp() : $timestamp,
             type: enum_value($type),
-            key: enum_value($key),
+            key: $this->sanitizeKey(enum_value($key)),
             value: $value,
         );
 
@@ -613,6 +613,18 @@ class Pulse
         $this->app = $container;
 
         return $this;
+    }
+
+    /**
+     * Sanitize a key to ensure it contains only valid UTF-8 characters.
+     */
+    protected function sanitizeKey(string $key): string
+    {
+        if (! mb_check_encoding($key, 'UTF-8')) {
+            $key = mb_convert_encoding($key, 'UTF-8', 'UTF-8');
+        }
+
+        return $key;
     }
 
     /**


### PR DESCRIPTION
## Summary

- When `pulse:work` processes entries containing invalid UTF-8 byte sequences in the `key` field (e.g., truncated multibyte characters, emojis in non-utf8mb4 databases, or raw binary data), MySQL raises `SQLSTATE[HY000]: General error: 1366 Incorrect string value` which crashes the worker.
- This adds UTF-8 sanitization to `Pulse::record()` and `Pulse::set()` to strip invalid byte sequences before storage, preventing the worker from crashing.

Fixes #455

## Test plan

- [ ] Record entries with keys containing emoji characters (e.g., SQL queries with emoji data)
- [ ] Record entries with keys containing truncated multibyte sequences
- [ ] Verify `pulse:work` continues processing without crashing on non-ASCII keys
- [ ] Verify valid UTF-8 keys (including standard ASCII) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)