### PR TITLE
Fix multi-server deadlocks with atomic Redis lock

### DIFF
--- a/src/Ingests/RedisIngest.php
+++ b/src/Ingests/RedisIngest.php
@@ -75,6 +75,22 @@ class RedisIngest implements Ingest
      */
     public function digest(Storage $storage): int
     {
+        if (! $this->acquireLock()) {
+            return 0;
+        }
+
+        try {
+            return $this->digestEntries($storage);
+        } finally {
+            $this->releaseLock();
+        }
+    }
+
+    /**
+     * Process the entries from the stream.
+     */
+    protected function digestEntries(Storage $storage): int
+    {
         $total = 0;
 
         while (true) {
@@ -103,6 +119,25 @@ class RedisIngest implements Ingest
 
             $total = $total + $entries->count();
         }
+    }
+
+    /**
+     * Acquire an exclusive lock for digesting entries.
+     */
+    protected function acquireLock(): bool
+    {
+        return $this->connection()->setnx(
+            $this->stream.':lock',
+            (int) $this->config->get('pulse.ingest.redis.lock_timeout', 30),
+        );
+    }
+
+    /**
+     * Release the digest lock.
+     */
+    protected function releaseLock(): void
+    {
+        $this->connection()->del($this->stream.':lock');
     }
 
     /**

--- a/src/Support/RedisAdapter.php
+++ b/src/Support/RedisAdapter.php
@@ -94,6 +94,42 @@ class RedisAdapter
     }
 
     /**
+     * Set a key with an expiry only if it does not already exist.
+     */
+    public function setnx(string $key, int $seconds): bool
+    {
+        $args = [
+            'SET',
+            $this->config->get('database.redis.options.prefix').$key,
+            '1',
+            'EX',
+            (string) $seconds,
+            'NX',
+        ];
+
+        try {
+            $result = $this->run($args);
+        } catch (PredisServerException $e) {
+            throw RedisServerException::whileRunningCommand(implode(' ', $args), $e->getMessage(), previous: $e);
+        }
+
+        // PhpRedis/Relay return true on success, false when the key already exists.
+        // Predis returns an OK status on success, null when the key already exists.
+        return $result !== null && $result !== false;
+    }
+
+    /**
+     * Delete one or more keys.
+     */
+    public function del(string $key): int
+    {
+        return (int) $this->handle([
+            'DEL',
+            $this->config->get('database.redis.options.prefix').$key,
+        ]);
+    }
+
+    /**
      * Run commands within a pipeline.
      *
      * @param  (callable(self): void)  $closure


### PR DESCRIPTION
## Summary
- When running `pulse:work` on multiple servers, concurrent digest operations on the same Redis stream can cause deadlocks
- Add an atomic `SET NX` lock with configurable timeout to ensure only one server digests entries at a time
- Add `setnx` and `del` methods to `RedisAdapter` for lock management

**Note:** This is a different fix from PR #1 (md5 to sha2 for issue #476). This addresses issue #461 specifically.

Fixes laravel/pulse#461

## Test plan
- [ ] Run `pulse:work` on multiple servers simultaneously and verify no deadlocks
- [ ] Verify single-server operation is unaffected
- [ ] Test lock timeout expiry (default 30s) to ensure recovery from crashed processes
- [ ] Verify configurable via `pulse.ingest.redis.lock_timeout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)