### PR TITLE
Fix Windows memory retrieval crashing on Windows 11 24H2+ by using PowerShell CIM

### DIFF
--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -137,7 +137,6 @@ class Servers
         $memoryUsed = match (PHP_OS_FAMILY) {
             'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'")) / 1024), // MB
-            'Windows' => $memoryTotal - intval(((int) trim((string) shell_exec('wmic OS get FreePhysicalMemory | more +1'))) / 1024), // MB
             'Windows' => $memoryTotal - self::getWindowsFreeMemoryMB(), // MB
             'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -129,7 +129,6 @@ class Servers
         $memoryTotal = match (PHP_OS_FAMILY) {
             'Darwin' => intval(intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'")) / 1024 / 1024),
             'Linux' => intval(intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'")) / 1024),
-            // 'Windows' => intval(((int) trim((string) shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
             'Windows' => self::getWindowsTotalMemoryMB(),
             'BSD' => intval(intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'")) / 1024 / 1024),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -155,14 +155,17 @@ class Servers
     {
         // Try PowerShell CIM first — wmic is deprecated and removed in Windows 11 24H2+
         $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"');
-        if ($output !== null && is_numeric(trim((string) $output))) {
-            return intval(intval(trim($output)) / 1024 / 1024);
+        $output = trim((string) $output);
+
+        if (is_numeric($output))) {
+            return intval((int) $output / 1024 / 1024);
         }
 
         // Fall back to wmic for older Windows versions
         $wmicOutput = shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1');
+        $wmicOutput = trim((string) $wmicOutput ?? '0');
 
-        return intval(intval(trim((string) $wmicOutput ?? '0')) / 1024 / 1024);
+        return intval((int) $wmicOutput / 1024 / 1024);
     }
 
     /**
@@ -173,13 +176,16 @@ class Servers
         // Try PowerShell CIM first — wmic is deprecated and removed in Windows 11 24H2+
         // FreePhysicalMemory from Win32_OperatingSystem is in KB
         $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory"');
-        if ($output !== null && is_numeric(trim($output))) {
-            return intval(intval(trim((string) $output)) / 1024);
+        $output = trim((string) $output);
+
+        if (is_numeric($output)) {
+            return intval((int) $output) / 1024);
         }
 
         // Fall back to wmic for older Windows versions
         $wmicOutput = shell_exec('wmic OS get FreePhysicalMemory | more +1');
+        $wmicOutput = trim((string) $wmicOutput ?? '0');
 
-        return intval(intval(trim((string) $wmicOutput ?? '0')) / 1024);
+        return intval((int) $wmicOutput / 1024);
     }
 }

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -152,14 +152,14 @@ class Servers
     {
         // Try PowerShell CIM first — wmic is deprecated and removed in Windows 11 24H2+
         $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"');
-        if ($output !== null && is_numeric(trim($output))) {
+        if ($output !== null && is_numeric(trim((string) $output))) {
             return intval(intval(trim($output)) / 1024 / 1024);
         }
 
         // Fall back to wmic for older Windows versions
         $wmicOutput = shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1');
 
-        return intval(intval(trim($wmicOutput ?? '0')) / 1024 / 1024);
+        return intval(intval(trim((string) $wmicOutput ?? '0')) / 1024 / 1024);
     }
 
     private static function getWindowsFreeMemoryMB(): int
@@ -168,12 +168,12 @@ class Servers
         // FreePhysicalMemory from Win32_OperatingSystem is in KB
         $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory"');
         if ($output !== null && is_numeric(trim($output))) {
-            return intval(intval(trim($output)) / 1024);
+            return intval(intval(trim((string) $output)) / 1024);
         }
 
         // Fall back to wmic for older Windows versions
         $wmicOutput = shell_exec('wmic OS get FreePhysicalMemory | more +1');
 
-        return intval(intval(trim($wmicOutput ?? '0')) / 1024);
+        return intval(intval(trim((string) $wmicOutput ?? '0')) / 1024);
     }
 }

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -129,7 +129,7 @@ class Servers
         $memoryTotal = match (PHP_OS_FAMILY) {
             'Darwin' => intval(intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'")) / 1024 / 1024),
             'Linux' => intval(intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'")) / 1024),
-            'Windows' => self::getWindowsTotalMemoryMB(),
+            'Windows' => $this->getWindowsTotalMemoryMB(),
             'BSD' => intval(intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'")) / 1024 / 1024),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
@@ -137,7 +137,7 @@ class Servers
         $memoryUsed = match (PHP_OS_FAMILY) {
             'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'")) / 1024), // MB
-            'Windows' => $memoryTotal - self::getWindowsFreeMemoryMB(), // MB
+            'Windows' => $memoryTotal - $this->getWindowsFreeMemoryMB(), // MB
             'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
@@ -148,7 +148,10 @@ class Servers
         ];
     }
 
-    private static function getWindowsTotalMemoryMB(): int
+    /**
+     * Total Memory on Windows.
+     */
+    private function getWindowsTotalMemoryMB(): int
     {
         // Try PowerShell CIM first — wmic is deprecated and removed in Windows 11 24H2+
         $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"');
@@ -162,7 +165,10 @@ class Servers
         return intval(intval(trim((string) $wmicOutput ?? '0')) / 1024 / 1024);
     }
 
-    private static function getWindowsFreeMemoryMB(): int
+    /**
+     * Free Memory on Windows.
+     */
+    private function getWindowsFreeMemoryMB(): int
     {
         // Try PowerShell CIM first — wmic is deprecated and removed in Windows 11 24H2+
         // FreePhysicalMemory from Win32_OperatingSystem is in KB

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -129,7 +129,8 @@ class Servers
         $memoryTotal = match (PHP_OS_FAMILY) {
             'Darwin' => intval(intval(shell_exec("sysctl hw.memsize | grep -Eo '[0-9]+'")) / 1024 / 1024),
             'Linux' => intval(intval(shell_exec("cat /proc/meminfo | grep MemTotal | grep -E -o '[0-9]+'")) / 1024),
-            'Windows' => intval(((int) trim((string) shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
+            // 'Windows' => intval(((int) trim((string) shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1'))) / 1024 / 1024),
+            'Windows' => self::getWindowsTotalMemoryMB(),
             'BSD' => intval(intval(shell_exec("sysctl hw.physmem | grep -Eo '[0-9]+'")) / 1024 / 1024),
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
@@ -138,6 +139,7 @@ class Servers
             'Darwin' => $memoryTotal - intval(intval(shell_exec("vm_stat | grep 'Pages free' | grep -Eo '[0-9]+'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             'Linux' => $memoryTotal - intval(intval(shell_exec("cat /proc/meminfo | grep MemAvailable | grep -E -o '[0-9]+'")) / 1024), // MB
             'Windows' => $memoryTotal - intval(((int) trim((string) shell_exec('wmic OS get FreePhysicalMemory | more +1'))) / 1024), // MB
+            'Windows' => $memoryTotal - self::getWindowsFreeMemoryMB(), // MB
             'BSD' => intval(intval(shell_exec("( sysctl vm.stats.vm.v_cache_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_inactive_count | grep -Eo '[0-9]+' ; sysctl vm.stats.vm.v_active_count | grep -Eo '[0-9]+' ) | awk '{s+=$1} END {print s}'")) * intval(shell_exec('pagesize')) / 1024 / 1024), // MB
             default => throw new RuntimeException('The pulse:check command does not currently support '.PHP_OS_FAMILY),
         };
@@ -146,5 +148,34 @@ class Servers
             'total' => $memoryTotal,
             'used' => $memoryUsed,
         ];
+    }
+
+    private static function getWindowsTotalMemoryMB(): int
+    {
+        // Try PowerShell CIM first — wmic is deprecated and removed in Windows 11 24H2+
+        $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"');
+        if ($output !== null && is_numeric(trim($output))) {
+            return intval(intval(trim($output)) / 1024 / 1024);
+        }
+
+        // Fall back to wmic for older Windows versions
+        $wmicOutput = shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1');
+
+        return intval(intval(trim($wmicOutput ?? '0')) / 1024 / 1024);
+    }
+
+    private static function getWindowsFreeMemoryMB(): int
+    {
+        // Try PowerShell CIM first — wmic is deprecated and removed in Windows 11 24H2+
+        // FreePhysicalMemory from Win32_OperatingSystem is in KB
+        $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory"');
+        if ($output !== null && is_numeric(trim($output))) {
+            return intval(intval(trim($output)) / 1024);
+        }
+
+        // Fall back to wmic for older Windows versions
+        $wmicOutput = shell_exec('wmic OS get FreePhysicalMemory | more +1');
+
+        return intval(intval(trim($wmicOutput ?? '0')) / 1024);
     }
 }

--- a/src/Recorders/Servers.php
+++ b/src/Recorders/Servers.php
@@ -157,13 +157,13 @@ class Servers
         $output = shell_exec('powershell -NoProfile -Command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"');
         $output = trim((string) $output);
 
-        if (is_numeric($output))) {
+        if (is_numeric($output)) {
             return intval((int) $output / 1024 / 1024);
         }
 
         // Fall back to wmic for older Windows versions
         $wmicOutput = shell_exec('wmic ComputerSystem get TotalPhysicalMemory | more +1');
-        $wmicOutput = trim((string) $wmicOutput ?? '0');
+        $wmicOutput = trim((string) $wmicOutput) ?: '0';
 
         return intval((int) $wmicOutput / 1024 / 1024);
     }
@@ -179,12 +179,12 @@ class Servers
         $output = trim((string) $output);
 
         if (is_numeric($output)) {
-            return intval((int) $output) / 1024);
+            return intval((int) $output / 1024);
         }
 
         // Fall back to wmic for older Windows versions
         $wmicOutput = shell_exec('wmic OS get FreePhysicalMemory | more +1');
-        $wmicOutput = trim((string) $wmicOutput ?? '0');
+        $wmicOutput = trim((string) $wmicOutput) ?: '0';
 
         return intval((int) $wmicOutput / 1024);
     }


### PR DESCRIPTION
Some background:

I maintain a package called [laravel-memory-health-check](https://github.com/ziming/laravel-memory-health-check) for the Spatie's Laravel Health package and Oh Dear

https://github.com/ziming/laravel-memory-health-check/

In my code, I used the memory usage check code from Laravel Pulse.

Not long ago, a user made an issue on my repo saying that the windows memory check crashes. As a non windows user, I ask AI to fix it and this is the fix AI comes out with.

According to the AI it says: "wmic is deprecated and removed in Windows 11 24H2+".

Then I asked the user to give it a try to see if it fixes it (since I'm not on Windows and the fix is AI generated). He replied yes that it is fixed.

https://github.com/ziming/laravel-memory-health-check/issues/4

So I'm making this PR to contribute back. Feel free to edit the code as you please