### PR TITLE
Add defer to script tags to guarantee that the DOM is fully loaded

### DIFF
--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -529,7 +529,7 @@ class Pulse
             throw new RuntimeException('Unable to load the Pulse dashboard JavaScript.');
         }
 
-        return "<script>{$livewire}</script>".PHP_EOL."<script>{$pulse}</script>".PHP_EOL;
+        return "<script defer>{$livewire}</script>".PHP_EOL."<script defer>{$pulse}</script>".PHP_EOL;
     }
 
     /**


### PR DESCRIPTION
## Fix: Add defer to script tags to prevent Alpine.js bootstrap errors

### Problem
The Alpine.js bootstrap error occurs intermittently because scripts execute before the DOM is fully ready. This causes race conditions where Alpine tries to initialize on elements that haven't been loaded yet.

### Solution
Added `defer` attribute to all relevant script tags to guarantee DOM is fully parsed before script execution.

### Changes
```html
<!-- Before -->
<script>{$livewire}</script>
<script>{$pulse}</script>

<!-- After -->
<script defer>{$livewire}</script>
<script defer>{$pulse}</script>
```