### PR TITLE
Fix Pulse ingest failure when database connection has `use_upsert_alias` enabled

### DIFF
--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -188,7 +188,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('`value` + values(`value`)'),
+                    'mariadb', 'mysql' => new Expression($this->mysqlUpsertTableColumn('value').' + '.$this->mysqlUpsertIncomingColumn('value')),
                     'pgsql', 'sqlite' => new Expression(<<<SQL
                         {$this->wrap('pulse_aggregates.value')} + "excluded"."value"
                         SQL),
@@ -210,7 +210,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('least(`value`, values(`value`))'),
+                    'mariadb', 'mysql' => new Expression('least('.$this->mysqlUpsertTableColumn('value').', '.$this->mysqlUpsertIncomingColumn('value').')'),
                     'pgsql' => new Expression(<<<SQL
                         least({$this->wrap('pulse_aggregates.value')}, "excluded"."value")
                         SQL),
@@ -235,7 +235,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('greatest(`value`, values(`value`))'),
+                    'mariadb', 'mysql' => new Expression('greatest('.$this->mysqlUpsertTableColumn('value').', '.$this->mysqlUpsertIncomingColumn('value').')'),
                     'pgsql' => new Expression(<<<SQL
                         greatest({$this->wrap('pulse_aggregates.value')}, "excluded"."value")
                         SQL),
@@ -260,7 +260,7 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
                 'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('`value` + values(`value`)'),
+                    'mariadb', 'mysql' => new Expression($this->mysqlUpsertTableColumn('value').' + '.$this->mysqlUpsertIncomingColumn('value')),
                     'pgsql', 'sqlite' => new Expression(<<<SQL
                         {$this->wrap('pulse_aggregates.value')} + "excluded"."value"
                         SQL),
@@ -282,8 +282,10 @@ class DatabaseStorage implements Storage
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             match ($driver = $this->connection()->getDriverName()) {
                 'mariadb', 'mysql' => [
-                    'value' => new Expression('(`value` * `count` + (values(`value`) * values(`count`))) / (`count` + values(`count`))'),
-                    'count' => new Expression('`count` + values(`count`)'),
+                    'value' => new Expression(
+                        '('.$this->mysqlUpsertTableColumn('value').' * '.$this->mysqlUpsertTableColumn('count').' + ('.$this->mysqlUpsertIncomingColumn('value').' * '.$this->mysqlUpsertIncomingColumn('count').')) / ('.$this->mysqlUpsertTableColumn('count').' + '.$this->mysqlUpsertIncomingColumn('count').')'
+                    ),
+                    'count' => new Expression($this->mysqlUpsertTableColumn('count').' + '.$this->mysqlUpsertIncomingColumn('count')),
                 ],
                 'pgsql', 'sqlite' => [
                     'value' => new Expression(<<<SQL
@@ -809,6 +811,35 @@ class DatabaseStorage implements Storage
                 fn ($query) => $query->pluck($aggregate, 'type'),
                 fn ($query) => (float) $query->value($aggregate)
             );
+    }
+
+    /**
+     * Determine if the connection uses row aliases for upsert statements.
+     */
+    protected function usesUpsertAlias(): bool
+    {
+        return in_array($this->connection()->getDriverName(), ['mysql', 'mariadb'], true)
+            && (bool) $this->connection()->getConfig('use_upsert_alias');
+    }
+
+    /**
+     * Reference an existing aggregate column in a MySQL upsert update clause.
+     */
+    protected function mysqlUpsertTableColumn(string $column): string
+    {
+        return $this->usesUpsertAlias()
+            ? $this->wrap('pulse_aggregates').'.'.$this->wrap($column)
+            : $this->wrap($column);
+    }
+
+    /**
+     * Reference an incoming aggregate column in a MySQL upsert update clause.
+     */
+    protected function mysqlUpsertIncomingColumn(string $column): string
+    {
+        return $this->usesUpsertAlias()
+            ? $this->wrap('laravel_upsert_alias').'.'.$this->wrap($column)
+            : 'values('.$this->wrap($column).')';
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Laravel\Pulse\Facades\Pulse;
+use Laravel\Pulse\Storage\DatabaseStorage;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
@@ -181,4 +182,36 @@ function livewireUpdateEndpoint()
 
     // Livewire v3
     return '/livewire/update';
+}
+
+function skipUnlessMySql(): void
+{
+    if (! in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'], true)) {
+        test()->markTestSkipped('MySQL or MariaDB is required for use_upsert_alias tests.');
+    }
+}
+
+function configureUpsertAlias(bool $enabled): void
+{
+    $connection = DB::getDefaultConnection();
+
+    Config::set("database.connections.{$connection}.use_upsert_alias", $enabled);
+
+    DB::purge($connection);
+}
+
+function invokeMysqlUpsertIncomingColumn(DatabaseStorage $storage, string $column): string
+{
+    $method = new ReflectionMethod(DatabaseStorage::class, 'mysqlUpsertIncomingColumn');
+    $method->setAccessible(true);
+
+    return $method->invoke($storage, $column);
+}
+
+function invokeMysqlUpsertTableColumn(DatabaseStorage $storage, string $column): string
+{
+    $method = new ReflectionMethod(DatabaseStorage::class, 'mysqlUpsertTableColumn');
+    $method->setAccessible(true);
+
+    return $method->invoke($storage, $column);
 }


### PR DESCRIPTION
## Summary
When a MySQL/MariaDB connection has `use_upsert_alias` enabled ([laravel/framework#42053](https://github.com/laravel/framework/pull/42053)), Laravel generates `INSERT … AS laravel_upsert_alias ON DUPLICATE KEY UPDATE` SQL. Pulse’s `DatabaseStorage` still built aggregate update clauses using `values(column)`, which is incompatible with that syntax and causes ingest to fail with an ambiguous column error.

This PR updates the MySQL/MariaDB upsert expressions in `DatabaseStorage` to use row-alias references when `use_upsert_alias` is enabled, while preserving the existing `values()` behaviour when it is disabled.

## Issue
With `use_upsert_alias => true` on the Pulse storage connection, aggregate upserts generate SQL similar to:
```sql
INSERT INTO `pulse_aggregates` (...)
VALUES (...)
AS laravel_upsert_alias
ON DUPLICATE KEY UPDATE `value` = `value` + values(`value`)
```
MySQL rejects this with:
```text
SQLSTATE[23000]: Column 'value' in field list is ambiguous
```
This is because `Pulse::ingest()` wraps storage in `rescue()`, the exception is captured by default and the dashboard appears empty with no obvious error.

PostgreSQL and SQLite are unaffected; they already use `"excluded"."column"` style references.

## Solution
- Add `usesUpsertAlias()`, `mysqlUpsertTableColumn()`, and `mysqlUpsertIncomingColumn()` helpers on `DatabaseStorage`.
- When `use_upsert_alias` is enabled:
  - Existing row: `` `pulse_aggregates`.`column` ``
  - Incoming row: `` `laravel_upsert_alias`.`column` ``
- When disabled (default / legacy):
  - Existing row: `` `column` ``
  - Incoming row: `` values(`column`) ``
Updated methods: `upsertCount`, `upsertMin`, `upsertMax`, `upsertSum`, `upsertAvg`.
## Test plan
- [x] Added `tests/Feature/Storage/MySqlUpsertAliasTest.php` (requires MySQL/MariaDB; skipped on SQLite)
  - Legacy mode (`use_upsert_alias=false`): SQL contains `values()`, ingest succeeds
  - Alias mode (`use_upsert_alias=true`): SQL contains `laravel_upsert_alias`, ingest succeeds
  - All aggregate types (count, min, max, sum, avg) ingest correctly with alias enabled
  - Documents pre-fix failure when alias + `values()` are mixed

## Backward compatibility
No breaking changes. Applications without `use_upsert_alias` continue to use `values()` as before.
