### PR TITLE
Support `use_upsert_alias` to prevent ingest failure 

### DIFF
--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -183,12 +183,18 @@ class DatabaseStorage implements Storage
      */
     protected function upsertCount(array $values): int
     {
-        return $this->connection()->table('pulse_aggregates')->upsert(
+        $connection = $this->connection();
+
+        return $connection->table('pulse_aggregates')->upsert(
             $values,
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
-                'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('`value` + values(`value`)'),
+                'value' => match ($driver = $connection->getDriverName()) {
+                    'mariadb', 'mysql' => new Expression(
+                        $connection->getConfig('use_upsert_alias')
+                            ? "{$this->wrap('pulse_aggregates.value')} + {$this->wrap('laravel_upsert_alias.value')}"
+                            : '`value` + values(`value`)'
+                    ),
                     'pgsql', 'sqlite' => new Expression(<<<SQL
                         {$this->wrap('pulse_aggregates.value')} + "excluded"."value"
                         SQL),
@@ -205,12 +211,18 @@ class DatabaseStorage implements Storage
      */
     protected function upsertMin(array $values): int
     {
-        return $this->connection()->table('pulse_aggregates')->upsert(
+        $connection = $this->connection();
+
+        return $connection->table('pulse_aggregates')->upsert(
             $values,
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
-                'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('least(`value`, values(`value`))'),
+                'value' => match ($driver = $connection->getDriverName()) {
+                    'mariadb', 'mysql' => new Expression(
+                        $connection->getConfig('use_upsert_alias')
+                            ? "least({$this->wrap('pulse_aggregates.value')}, {$this->wrap('laravel_upsert_alias.value')})"
+                            : 'least(`value`, values(`value`))'
+                    ),
                     'pgsql' => new Expression(<<<SQL
                         least({$this->wrap('pulse_aggregates.value')}, "excluded"."value")
                         SQL),
@@ -230,12 +242,18 @@ class DatabaseStorage implements Storage
      */
     protected function upsertMax(array $values): int
     {
-        return $this->connection()->table('pulse_aggregates')->upsert(
+        $connection = $this->connection();
+
+        return $connection->table('pulse_aggregates')->upsert(
             $values,
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
-                'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('greatest(`value`, values(`value`))'),
+                'value' => match ($driver = $connection->getDriverName()) {
+                    'mariadb', 'mysql' => new Expression(
+                        $connection->getConfig('use_upsert_alias')
+                            ? "greatest({$this->wrap('pulse_aggregates.value')}, {$this->wrap('laravel_upsert_alias.value')})"
+                            : 'greatest(`value`, values(`value`))'
+                    ),
                     'pgsql' => new Expression(<<<SQL
                         greatest({$this->wrap('pulse_aggregates.value')}, "excluded"."value")
                         SQL),
@@ -255,12 +273,18 @@ class DatabaseStorage implements Storage
      */
     protected function upsertSum(array $values): int
     {
-        return $this->connection()->table('pulse_aggregates')->upsert(
+        $connection = $this->connection();
+
+        return $connection->table('pulse_aggregates')->upsert(
             $values,
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
             [
-                'value' => match ($driver = $this->connection()->getDriverName()) {
-                    'mariadb', 'mysql' => new Expression('`value` + values(`value`)'),
+                'value' => match ($driver = $connection->getDriverName()) {
+                    'mariadb', 'mysql' => new Expression(
+                        $connection->getConfig('use_upsert_alias')
+                            ? "{$this->wrap('pulse_aggregates.value')} + {$this->wrap('laravel_upsert_alias.value')}"
+                            : '`value` + values(`value`)'
+                    ),
                     'pgsql', 'sqlite' => new Expression(<<<SQL
                         {$this->wrap('pulse_aggregates.value')} + "excluded"."value"
                         SQL),
@@ -277,11 +301,20 @@ class DatabaseStorage implements Storage
      */
     protected function upsertAvg(array $values): int
     {
-        return $this->connection()->table('pulse_aggregates')->upsert(
+        $connection = $this->connection();
+
+        return $connection->table('pulse_aggregates')->upsert(
             $values,
             ['bucket', 'period', 'type', 'aggregate', 'key_hash'],
-            match ($driver = $this->connection()->getDriverName()) {
-                'mariadb', 'mysql' => [
+            match ($driver = $connection->getDriverName()) {
+                'mariadb', 'mysql' => $connection->getConfig('use_upsert_alias') ? [
+                    'value' => new Expression(
+                        "({$this->wrap('pulse_aggregates.value')} * {$this->wrap('pulse_aggregates.count')} + ({$this->wrap('laravel_upsert_alias.value')} * {$this->wrap('laravel_upsert_alias.count')})) / ({$this->wrap('pulse_aggregates.count')} + {$this->wrap('laravel_upsert_alias.count')})"
+                    ),
+                    'count' => new Expression(
+                        "{$this->wrap('pulse_aggregates.count')} + {$this->wrap('laravel_upsert_alias.count')}"
+                    ),
+                ] : [
                     'value' => new Expression('(`value` * `count` + (values(`value`) * values(`count`))) / (`count` + values(`count`))'),
                     'count' => new Expression('`count` + values(`count`)'),
                 ],

--- a/tests/Feature/Storage/MySqlUpsertAliasTest.php
+++ b/tests/Feature/Storage/MySqlUpsertAliasTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Laravel\Pulse\Facades\Pulse;
+use Laravel\Pulse\Storage\DatabaseStorage;
+
+describe('MySQL aggregate upserts and use_upsert_alias', function () {
+    beforeEach(function () {
+        skipUnlessMySql();
+
+        App::make(DatabaseStorage::class)->purge();
+    });
+
+    dataset('upsert alias modes', [
+        'before (legacy values() syntax)' => [false, 'values(`value`)', 'laravel_upsert_alias'],
+        'after (row alias syntax)' => [true, 'laravel_upsert_alias', 'values(`value`)'],
+    ]);
+
+    it('ingests count aggregates and emits the expected upsert SQL', function (bool $useUpsertAlias, string $expectedFragment, string $forbiddenFragment) {
+        configureUpsertAlias($useUpsertAlias);
+
+        $aggregateQueries = collect();
+
+        DB::listen(function (QueryExecuted $event) use (&$aggregateQueries) {
+            if (str_contains($event->sql, 'pulse_aggregates') && str_contains(strtolower($event->sql), 'on duplicate')) {
+                $aggregateQueries->push($event->sql);
+            }
+        });
+
+        Pulse::record('upsert_alias_test', 'test-key', 1)->count();
+        expect(Pulse::ingest())->toBe(1);
+
+        Pulse::record('upsert_alias_test', 'test-key', 1)->count();
+        expect(Pulse::ingest())->toBe(1);
+
+        expect($aggregateQueries)->not->toBeEmpty();
+
+        $sql = $aggregateQueries->last();
+
+        expect($sql)->toContain($expectedFragment);
+        expect($sql)->not->toContain($forbiddenFragment);
+
+        if ($useUpsertAlias) {
+            expect($sql)->toContain('as laravel_upsert_alias');
+            expect($sql)->toContain('`pulse_aggregates`');
+        } else {
+            expect($sql)->not->toContain('as laravel_upsert_alias');
+        }
+
+        $stored = Pulse::ignore(fn () => DB::table('pulse_aggregates')
+            ->where('type', 'upsert_alias_test')
+            ->where('aggregate', 'count')
+            ->where('key', 'test-key')
+            ->where('period', 60)
+            ->value('value'));
+
+        expect((int) $stored)->toBe(2);
+    })->with('upsert alias modes');
+
+    it('ingests min, max, sum, and avg aggregates when use_upsert_alias is enabled', function () {
+        configureUpsertAlias(true);
+
+        Pulse::record('upsert_alias_test', 'avg-key', 100)->count()->min()->max()->sum()->avg();
+        Pulse::record('upsert_alias_test', 'avg-key', 300)->count()->min()->max()->sum()->avg();
+        expect(Pulse::ingest())->toBe(2);
+
+        $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')
+            ->where('type', 'upsert_alias_test')
+            ->where('key', 'avg-key')
+            ->where('period', 60)
+            ->pluck('value', 'aggregate'));
+
+        expect((int) ($aggregates['count'] ?? 0))->toBe(2);
+        expect((int) ($aggregates['min'] ?? 0))->toBe(100);
+        expect((int) ($aggregates['max'] ?? 0))->toBe(300);
+        expect((int) ($aggregates['sum'] ?? 0))->toBe(400);
+        expect((int) ($aggregates['avg'] ?? 0))->toBe(200);
+    });
+
+    it('documents the pre-fix failure when row alias is mixed with values()', function () {
+        configureUpsertAlias(true);
+
+        $brokenSql = <<<'SQL'
+            insert into `pulse_aggregates` (`aggregate`, `bucket`, `key`, `period`, `type`, `value`)
+            values ('count', 1, 'key', 60, 'broken_test', 1)
+            as laravel_upsert_alias
+            on duplicate key update `value` = `value` + values(`value`)
+            SQL;
+
+        try {
+            expect(fn () => DB::statement($brokenSql))
+                ->toThrow(QueryException::class);
+        } finally {
+            Pulse::flush();
+        }
+    });
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -182,3 +182,19 @@ function livewireUpdateEndpoint()
     // Livewire v3
     return '/livewire/update';
 }
+
+function skipUnlessMySql(): void
+{
+    if (! in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'], true)) {
+        test()->markTestSkipped('MySQL or MariaDB is required for use_upsert_alias tests.');
+    }
+}
+
+function configureUpsertAlias(bool $enabled): void
+{
+    $connection = DB::getDefaultConnection();
+
+    Config::set("database.connections.{$connection}.use_upsert_alias", $enabled);
+
+    DB::purge($connection);
+}


### PR DESCRIPTION
Hey 👋 

This PR adds support for `use_upsert_alias` which was added to the framework several years ago in https://github.com/laravel/framework/pull/42053. If you're using MySQL or MariaDB and have `use_upsert_alias` set to `true` in `database.php`, the ingest fails with the following:

> [previous exception] [object] (PDOException(code: 23000): SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'value' in field list is ambiguous

I've tested this fix on local instances of MySQL and MariaDB and can confirm the ingest works as expected:

MySQL
<img width="770" height="275" alt="Screenshot 2026-05-21 at 19 29 05" src="https://github.com/user-attachments/assets/67e5de73-304f-47a5-a0db-8798e1f6ba86" />

MariaDB
<img width="770" height="275" alt="Screenshot 2026-05-21 at 19 40 14" src="https://github.com/user-attachments/assets/3ed094be-6cb5-441e-b89c-a2af7422409c" />

Please let me know if anything needs changing! 

This is a re-attempt of https://github.com/laravel/pulse/pull/510 - I realised amongst other things that the tests weren't even committed 🤦 I hope this attempt is better! 
