### PR TITLE
[1.x] Allow guzzlehttp/promises ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "doctrine/sql-formatter": "^1.4.1",
-        "guzzlehttp/promises": "^1.0|^2.0",
+        "guzzlehttp/promises": "^1.0|^2.0|^3.0",
         "illuminate/auth": "^10.48.4|^11.0.8|^12.0|^13.0",
         "illuminate/cache": "^10.48.4|^11.0.8|^12.0|^13.0",
         "illuminate/config": "^10.48.4|^11.0.8|^12.0|^13.0",
@@ -40,7 +40,7 @@
         "symfony/console": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.7",
+        "guzzlehttp/guzzle": "^7.7|^8.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
         "pestphp/pest": "^2.0|^3.0|^4.0",


### PR DESCRIPTION
Guzzle 8 requires `guzzlehttp/promises: ^3.0.1`, but Pulse caps it at `^1.0|^2.0`. Since `laravel/framework` already permits `guzzle ^8.0`, this cap is the remaining blocker stopping any Laravel 13.26+ application that uses Pulse from moving to Guzzle 8.

This PR widens the constraint to `^1.0|^2.0|^3.0`.

### Why this looks safe

Pulse's entire `guzzlehttp/promises` surface is two lines in one file — the import, and one constructor call in `src/Recorders/SlowOutgoingRequests.php`:

```php
return new RejectedPromise($exception);
```

`RejectedPromise::__construct()` is unchanged between promises 2.5.2 and 3.0.1. Comparing the two tags' `src/RejectedPromise.php` with comments, docblocks and whitespace stripped, the **only** runtime difference in the whole class is:

```diff
-    public function resolve($value): void
+    public function resolve($value = null): void
```

That is a widening (a parameter gained a default), and it is not a method Pulse calls. The rest of the file's growth between the two tags is generics annotations (`@template`, `@implements`), which have no runtime effect.

### Why `require-dev` changes too

`guzzlehttp/guzzle: ^7.7` requires `promises ^2.5.2`, so with only the `require` change Composer resolves the dev tree back to promises 2.x and the widened constraint is never actually exercised by CI. Widening the dev constraint to `^7.7|^8.0` is what makes the test run meaningful.

### Test results

Run against `1.x` at 950cb8a, PHP 8.5.1. I ran the suite twice — once patched, once on an untouched clone of the same commit — because otherwise the failures below aren't attributable.

| | promises | guzzle | psr7 | Result |
|---|---|---|---|---|
| **Patched** | 3.0.1 | 8.0.2 | 3.0.0 | 2 failed, 32 skipped, 195 passed (2747 assertions) |
| **Control** (unmodified) | 2.5.2 | 7.15.3 | 2.13.0 | 2 failed, 32 skipped, 195 passed (2747 assertions) |

The two failures are identical in both runs — `Tests\Feature\Livewire\CacheTest > it does not round numbers up` and `> it does not show decimals for round numbers`. They are pre-existing on unmodified `1.x`, are number-formatting assertions, and touch no Guzzle code. Assertion totals match exactly, so the failing sets are the same rather than coincidentally equal counts.

**Zero new failures are attributable to promises 3.**

The rejection path specifically — which is the only thing this change can realistically affect — is fully green:

```
PASS  Tests\Feature\Recorders\SlowOutgoingRequestsTest
PASS  Tests\Feature\Livewire\SlowOutgoingRequestsTest
Tests: 17 passed (133 assertions)
```

including `it captures failed requests`, which is the test that drives the `RejectedPromise` path. No skips in that group.

Happy to adjust the approach if you'd rather handle the dev-constraint side differently, or drop it and test promises 3 some other way.
