### PR TITLE
Never fail the request pipeline when normalizing an unparseable slow outgoing request URL

### DIFF
--- a/src/Recorders/SlowOutgoingRequests.php
+++ b/src/Recorders/SlowOutgoingRequests.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Client\Factory;
 use Laravel\Pulse\Concerns\ConfiguresAfterResolving;
 use Laravel\Pulse\Pulse;
+use League\Uri\Exceptions\SyntaxError;
 use League\Uri\Uri;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -96,7 +97,13 @@ class SlowOutgoingRequests
      */
     public static function normalizeUrl(string $url): string
     {
-        $uri = Uri::new($url);
+        try {
+            $uri = Uri::new($url);
+        } catch (SyntaxError) {
+            // Guzzle accepted this URI, but it cannot be parsed here. Strip any
+            // user info conservatively rather than failing the request pipeline.
+            return preg_replace('~://[^/?#]*@~', '://', $url);
+        }
 
         if (is_null($uri->getUsername())) {
             return $url;

--- a/tests/Unit/Recorders/SlowOutgoingRequestsTest.php
+++ b/tests/Unit/Recorders/SlowOutgoingRequestsTest.php
@@ -9,3 +9,10 @@ it('can normalize URLs', function (string $given, string $expected) {
     ['https://laravel@httpbin.org/delay/2', 'https://@httpbin.org/delay/2'],
     ['https://laravel:password@httpbin.org/delay/2', 'https://@httpbin.org/delay/2'],
 ]);
+
+it('strips user info from URLs that cannot be parsed instead of throwing', function () {
+    expect(SlowOutgoingRequests::normalizeUrl("https://laravel:password@httpbin.org/delay/2\n"))
+        ->toBe('https://httpbin.org/delay/2'.PHP_EOL)
+        ->and(SlowOutgoingRequests::normalizeUrl("https://httpbin.org/delay/2\n"))
+        ->toBe('https://httpbin.org/delay/2'.PHP_EOL);
+});


### PR DESCRIPTION
`SlowOutgoingRequests::normalizeUrl()` parses every recorded URI with `League\Uri\Uri::new()`, which throws `SyntaxError` on URIs containing raw newlines or other invalid characters. The recorder runs synchronously inside an HTTP client middleware `then()` handler, so a throw there replaces an already-successful upstream response with a rejected promise and surfaces as an application error. Guzzle's own PSR-7 percent-encodes most of these at assignment time, but custom PSR-7 implementations and direct component injection can still produce them.

This catches the parse failure and falls back to stripping user info with a conservative regex, so credential masking (the point of #529) is preserved without ever breaking live traffic.

Added unit tests covering unparseable URLs with and without credentials.